### PR TITLE
ci: add PyPI Trusted Publishing workflow (publish on tag)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: CI & Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"] # tag like v0.3.1 to publish to PyPI
+  workflow_dispatch:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install deps (dev)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Type-check
+        run: mypy
+
+      - name: Tests (skipped if none)
+        run: |
+          if [ -d tests ] || ls -1 **/*_test.py **/test_*.py >/dev/null 2>&1; then
+            pytest -q
+          else
+            echo "No tests found, skipping pytest."
+          fi
+
+  build:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build sdist+wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish-pypi:
+    # Publish ONLY when a tag v* is pushed
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # REQUIRED for PyPI Trusted Publishing (no API token)
+      contents: read
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist


### PR DESCRIPTION
Adds GitHub Actions workflow to build sdist+wheel and publish to PyPI via
Trusted Publishing (OIDC) when a tag matching v* is pushed.

- Runs ruff + mypy checks (pytest is skipped if no tests exist)
- Builds with `python -m build`
- Publishes on tag via pypa/gh-action-pypi-publish

Follow-up to recent CLI fixes so releases are easy to cut.
