### PR TITLE
ci: add PyPI Trusted Publishing workflow (publish on tag)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install deps (dev)
+      - name: Install deps (dev + deep)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,deep]"
 
       - name: Lint
         run: |
@@ -26,7 +26,7 @@ jobs:
           ruff format --check .
 
       - name: Type-check
-        run: mypy
+        run: mypy deepmcpagent
 
       - name: Tests (skipped if none)
         run: |


### PR DESCRIPTION
### Changes
- CI: Add GitHub Actions workflow (`.github/workflows/publish.yml`) to build sdist+wheel
  and publish to PyPI via Trusted Publishing (OIDC) when a tag matching `v*` is pushed.
  - Quality job runs `ruff check`, `ruff format --check`, and `mypy deepmcpagent`
  - Installs dev+deep extras for parity with local: `pip install -e ".[dev,deep]"`
  - Builds with `python -m build`
  - Publishes with `pypa/gh-action-pypi-publish`
- CLI: Fix Ruff `B008` by switching from `typer.Option(...)` defaults to Typer’s
  `Annotated` style. No behavioral changes; `--version` works and flattened `--stdio`/`--http`
  parsing remains.

### Why
- Streamlined releases: bump `pyproject.toml` version and push a tag (e.g., `v0.3.1`) to publish.
- Code quality: Ruff strict mode passes without suppressions; modern Typer pattern adopted.

### How to release (after merge)
1. Update `[project] version` in `pyproject.toml` (e.g., `0.3.1`).
2. Tag and push:
   ```bash
   git tag -a v0.3.1 -m "release: 0.3.1 — CLI Ruff fix + CI publish"
   git push origin v0.3.1
````

3. The `publish-pypi` job will upload the artifacts to PyPI.

### Checklist

* [x] `ruff check .` and `ruff format --check .` pass
* [x] `mypy deepmcpagent` passes
* [x] No extraneous files
* [x] DCO: commits are signed off

Signed-off-by: Ruben M. [[cryxnet@proton.me](mailto:cryxnet@proton.me)](mailto:cryxnet@proton.me)
