### PR TITLE
ci: fix workflow install to skip deep extra on Python 3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install deps (dev + deep)
+      - name: Install deps (dev)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,deep]"
+          pip install -e ".[dev]"
 
       - name: Lint
         run: |


### PR DESCRIPTION
### Changes
- Run GitHub Actions CI on Python 3.10 (minimum supported version).
- Install only .[dev] extras; skip .[deep] because deepagents>=0.0.5rc1 requires Python >=3.11.
- Lint, type-check, and build remain the same.
- Publish to PyPI on tag unaffected.

### Why
- Avoid CI install failure caused by deepagents on Python 3.10.
- Keep checks focused on minimum supported version while still ensuring code quality.

### Checklist
- [x] ruff passes
- [x] mypy passes on deepmcpagent
- [x] Workflow builds artifacts successfully
- [x] DCO: commits are signed off
