### PR TITLE
fix(types): resolve mypy errors in cli, agent, tools, and clients

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           ruff format --check .
 
       - name: Type-check
-        run: mypy deepmcpagent
+        run: mypy src
 
       - name: Tests (skipped if none)
         run: |

--- a/src/deepmcpagent/clients.py
+++ b/src/deepmcpagent/clients.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any  # <-- add
 
 from fastmcp import Client as FastMCPClient
 
@@ -21,9 +22,9 @@ class FastMCPMulti:
 
     def __init__(self, servers: Mapping[str, ServerSpec]) -> None:
         mcp_cfg = {"mcpServers": servers_to_mcp_config(servers)}
-        self._client = FastMCPClient(mcp_cfg)
+        self._client: Any = FastMCPClient(mcp_cfg)  # <-- annotate as Any
 
     @property
-    def client(self) -> FastMCPClient:
+    def client(self) -> Any:  # <-- return Any to avoid unparameterized generic
         """Return the underlying FastMCP client instance."""
         return self._client


### PR DESCRIPTION
- Added return type annotations to CLI commands and async helpers
- Reordered required/optional arguments in CLI to satisfy Python + Typer
- Casted FastMCP Client to Any to avoid missing type params
- Fixed create_model overload typing in tools with proper cast
- Parameterized Runnable with Any to satisfy mypy strict mode

This brings the codebase back to passing mypy strict checks.