### PR TITLE
feat(cross-agent): in-process Cross Agent Communication via ask_agent_* & broadcast_to_agents

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,21 +2,4 @@
 
 This page documents the public Python API exposed by `deepmcpagent`.
 
-## Agent
-
-::: deepmcpagent.agent.build_deep_agent
-
-## Config
-
-::: deepmcpagent.config.HTTPServerSpec
-::: deepmcpagent.config.StdioServerSpec
-::: deepmcpagent.config.servers_to_mcp_config
-
-## Clients
-
-::: deepmcpagent.clients.FastMCPMulti
-
-## Tools
-
-::: deepmcpagent.tools.MCPToolLoader
-::: deepmcpagent.tools.ToolInfo
+::: deepmcpagent

--- a/docs/cross-agent.md
+++ b/docs/cross-agent.md
@@ -1,0 +1,297 @@
+## What are "Cross Agents"?
+
+**Cross agents** are other agent graphs (LangGraph ReAct or DeepAgents loops) that you expose to a calling agent as tools. Each peer is surfaced as:
+
+- `ask_agent_<name>` — forward a single question to a specific peer and return its final answer.
+- `broadcast_to_agents` — ask multiple peers the same question in parallel and return a mapping of answers.
+
+This makes multi-agent patterns feel like calling any other MCP tool: the caller reasons about _when_ to delegate; the peer focuses on _how_ to solve its slice.
+
+---
+
+## How it works (high level)
+
+1. You build (or already have) one or more agent runnables: `Runnable[{messages}] -> Result`.
+2. Wrap those peers with `CrossAgent(agent=..., description=...)`.
+3. Pass `cross_agents={...}` into `build_deep_agent(...)` for your main agent.
+4. The builder automatically attaches:
+
+   - one `ask_agent_<peer>` tool per peer
+   - an optional `broadcast_to_agents` tool
+
+5. During planning, the main agent can call these tools like any other MCP tool.
+
+Internally, the tools:
+
+- Package your prompt as `{ "messages": [...] }` and call `peer.ainvoke(...)`.
+- Extract a “best final text” from the peer’s result (compatible with LangGraph/DeepAgents common shapes).
+- Return that text (or a dict of texts for broadcast) to the caller.
+
+---
+
+## Installation & prerequisites
+
+You already have DeepMCPAgent. Ensure your env can run your chosen chat model(s) via LangChain’s `init_chat_model` strings (e.g., `openai:gpt-4.1`, `anthropic:messages-2025-xx`), and that any MCP servers you want are reachable.
+
+> Works with both **DeepAgents** (if installed) and the **LangGraph prebuilt ReAct agent** fallback.
+
+---
+
+## Quick start
+
+### 1) Build a specialist peer agent
+
+```python
+from deepmcpagent.agent import build_deep_agent
+from deepmcpagent.config import HTTPServerSpec
+
+research_graph, _ = await build_deep_agent(
+    servers={"web": HTTPServerSpec(url="http://127.0.0.1:8000/mcp")},
+    model="openai:gpt-4o-mini",
+)
+```
+
+### 2) Build your main agent and attach the peer
+
+```python
+from deepmcpagent.agent import build_deep_agent
+from deepmcpagent.cross_agent import CrossAgent
+
+main_graph, _ = await build_deep_agent(
+    servers={"files": HTTPServerSpec(url="http://127.0.0.1:9000/mcp")},
+    model="openai:gpt-4.1",
+    cross_agents={
+        "researcher": CrossAgent(
+            agent=research_graph,
+            description="Focused web researcher that gathers and summarizes sources."
+        )
+    },
+)
+```
+
+### 3) Use it in a chat loop
+
+```python
+result = await main_graph.ainvoke({
+    "messages": [{"role": "user", "content": "Draft a brief on Topic X"}]
+})
+# During planning the main agent may call:
+#   - ask_agent_researcher(message=..., context?=..., timeout_s?=...)
+#   - broadcast_to_agents(message=..., peers?=[...], timeout_s?=...)
+```
+
+---
+
+## Tool API
+
+### `ask_agent_<name>`
+
+**Purpose:** Ask a specific peer a question and get the peer’s final answer.
+
+**Input schema**
+
+```json
+{
+  "message": "string (required)",
+  "context": "string (optional)",
+  "timeout_s": "number (optional, seconds)"
+}
+```
+
+- `message`: The user-level query to forward.
+- `context`: Extra caller context (constraints, partial results, style guide). Sent first as a `system` message to bias many executors helpfully.
+- `timeout_s`: Per-call timeout; returns a “Timed out” message if exceeded.
+
+**Return:** `string` — best-effort final text from the peer.
+
+---
+
+### `broadcast_to_agents`
+
+**Purpose:** Ask multiple peers the same question in parallel.
+
+**Input schema**
+
+```json
+{
+  "message": "string (required)",
+  "peers": ["string", "... (optional)"],
+  "timeout_s": "number (optional, seconds)"
+}
+```
+
+- `peers`: Subset of peer names; omit to use all.
+- `timeout_s`: Per-peer timeout.
+
+**Return:** `object` mapping peer name → final text answer, e.g.
+
+```json
+{
+  "researcher": "Summary ...",
+  "editor": "Refined draft ...",
+  "critic": "Risks list ..."
+}
+```
+
+---
+
+## Examples & patterns
+
+### Specialist delegation
+
+- **Researcher → Writer → Editor**: The main agent requests sources via `ask_agent_researcher`, drafts with local tools, then sends the draft to an `editor` peer for tone/clarity.
+
+### Ensemble consensus
+
+- Broadcast to `{ "math", "python", "reasoner" }`, then summarize or vote on the best answer.
+
+### Safety gatekeeping
+
+- Route candidate content to a `safety` peer for policy checks before finalizing.
+
+### RAG aggregator
+
+- A peer dedicated to retrieval; main agent calls it when tool descriptions mention “search”, “vector”, or “db” tasks.
+
+---
+
+## Tracing & debugging
+
+Enable tool tracing to see cross-agent calls and outputs:
+
+```bash
+deepmcpagent run \
+  --model-id openai:gpt-4.1 \
+  --http "name=files url=http://127.0.0.1:9000/mcp" \
+  --trace
+```
+
+Programmatically, pass `trace_tools=True` into `build_deep_agent(...)` to get console prints like:
+
+```
+→ Invoking tool: ask_agent_researcher with {'message': '...'}
+✔ Tool result from ask_agent_researcher: <peer final text>
+```
+
+---
+
+## Error handling & timeouts
+
+- Transport/peer errors surface as `MCPClientError` or `ValueError` (e.g., unknown peer in broadcast).
+- Use `timeout_s` to keep the caller responsive.
+- The broadcast tool returns `"Timed out"` for slow peers without failing the whole call.
+
+---
+
+## Design notes
+
+- **Zero new infra:** Peers are plain in-process runnables; no extra MCP servers needed to talk agent-to-agent.
+- **LLM-native delegation:** Uses standard tool calls, so planning remains transparent and controllable.
+- **Composable & optional:** `cross_agents` is a single optional arg; if omitted, nothing changes.
+- **Parallel fan-out:** Broadcast leverages `anyio.gather` for concurrent peer calls.
+
+---
+
+## Compatibility
+
+- **DeepAgents available:** Uses the DeepAgents loop under the hood when present.
+- **Otherwise:** Falls back to LangGraph’s `create_react_agent`. Prompt injection via `system_prompt` / `state_modifier` is handled across versions.
+
+---
+
+## Security & privacy boundaries
+
+- Only the `message` (and optional `context`) are sent to peers.
+- Avoid passing secrets in `context`. Prefer secret storage and tool-level auth for sensitive operations.
+
+---
+
+## Performance tips
+
+- Keep peers focused and lightweight; the caller can decide _when_ to delegate.
+- Use `timeout_s` for high-latency peers or external retrieval.
+- Consider smaller/cheaper models for “filter” or “triage” peers; reserve larger models for synthesis.
+
+---
+
+## Testing
+
+### Unit test a single ask
+
+```python
+import pytest
+from langchain_core.runnables import RunnableLambda
+from deepmcpagent.cross_agent import CrossAgent, make_cross_agent_tools
+
+async def fake_peer(inputs):
+    return {"messages": [{"role": "assistant", "content": "ok"}]}
+
+def test_ask_agent_tool():
+    peer = CrossAgent(agent=RunnableLambda(fake_peer))
+    tools = make_cross_agent_tools({"peer": peer})
+    ask = next(t for t in tools if t.name == "ask_agent_peer")
+    out = pytest.run(asyncio.run(ask._arun(message="ping")))  # or use anyio
+    assert out == "ok"
+```
+
+### Integration test with your builder
+
+- Build two agents with trivial models or stubs.
+- Attach via `cross_agents`.
+- Invoke a prompt that forces a tool call (e.g., “Ask the researcher for sources and summarize”).
+
+---
+
+## Migration from single-agent setups
+
+You don’t have to change your MCP servers or model configs. Introduce peers gradually by:
+
+1. Building a small specialist peer (`research`, `editor`, `critic`).
+2. Attaching it via `cross_agents`.
+3. Nudging your system prompt to allow delegation: _“If a peer tool is available and more capable, delegate.”_
+
+---
+
+## Reference (Public API)
+
+### `CrossAgent`
+
+```python
+CrossAgent(
+  agent: Runnable[Any, Any],
+  description: str = ""
+)
+```
+
+### `build_deep_agent(..., cross_agents=...)`
+
+```python
+main_graph, loader = await build_deep_agent(
+  servers=...,                # Mapping[str, ServerSpec]
+  model="openai:gpt-4.1",     # or BaseChatModel or Runnable
+  instructions=None,          # optional
+  trace_tools=True,           # optional
+  cross_agents={
+    "researcher": CrossAgent(agent=peer_graph, description="..."),
+    # more peers...
+  }
+)
+```
+
+**Auto-added tools**
+
+- `ask_agent_<name>(message: str, context?: str, timeout_s?: float) -> str`
+- `broadcast_to_agents(message: str, peers?: list[str], timeout_s?: float) -> dict[str, str]`
+
+---
+
+## Roadmap
+
+- Remote peers (HTTP/SSE) with the same API.
+- Streaming replies & “live debate” orchestration.
+- Capability tagging & auto-routing (“use the best peer for X”).
+- Observability hooks (spans/metrics per peer call).
+
+---
+
+_That’s it—plug in a peer, flip on tracing, and you’ve got cooperative agents without extra plumbing._

--- a/examples/use_cross_agent.py
+++ b/examples/use_cross_agent.py
@@ -1,0 +1,158 @@
+# use_cross_agent.py
+"""
+Example: Cross-Agent Communication with DeepMCPAgent.
+
+This demonstrates wiring a specialist peer agent into a primary agent so the
+primary can delegate work via cross-agent tools:
+
+- ask_agent_<name>(message, context?, timeout_s?)
+- broadcast_to_agents(message, peers?, timeout_s?)
+
+Console output:
+- Discovered MCP tools (from your servers)
+- Advertised cross-agent tools (derived from peers)
+- Each tool invocation + result (via deepmcpagent trace hooks)
+- Final LLM answer
+"""
+
+import asyncio
+from typing import Any
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from deepmcpagent import HTTPServerSpec, build_deep_agent
+from deepmcpagent.cross_agent import CrossAgent
+
+
+def _extract_final_answer(result: Any) -> str:
+    """Best-effort extraction of the final text from different executors."""
+    try:
+        # LangGraph prebuilt typically returns {"messages": [...]}
+        if isinstance(result, dict) and "messages" in result and result["messages"]:
+            last = result["messages"][-1]
+            content = getattr(last, "content", None)
+            if isinstance(content, str) and content:
+                return content
+            if isinstance(content, list) and content and isinstance(content[0], dict):
+                return content[0].get("text") or str(content)
+            return str(last)
+        return str(result)
+    except Exception:
+        return str(result)
+
+
+async def main() -> None:
+    console = Console()
+    load_dotenv()
+
+    # Ensure your MCP server (e.g., math_server.py) is running in another terminal:
+    #   python math_server.py
+    servers = {
+        "math": HTTPServerSpec(
+            url="http://127.0.0.1:8000/mcp",
+            transport="http",
+        ),
+    }
+
+    # Any LangChain-compatible chat model (or init string) works here.
+    # Use the same or different models for main/peer agents as you prefer.
+    main_model = ChatOpenAI(model="gpt-4.1")
+    peer_model = ChatOpenAI(model="gpt-4o-mini")
+
+    # ---------------------------------------------------------------------
+    # 1) Build a specialist peer agent (math-focused)
+    # ---------------------------------------------------------------------
+    math_peer_graph, _ = await build_deep_agent(
+        servers=servers,
+        model=peer_model,
+        instructions=(
+            "You are a focused Math Specialist. ALWAYS use available MCP math tools "
+            "to compute precisely. Return concise numeric results with brief steps."
+        ),
+        trace_tools=True,  # See the math peer's own tool usage when directly invoked
+    )
+
+    # Wrap the peer as a CrossAgent so it can be exposed as a tool.
+    peers = {
+        "mathpeer": CrossAgent(
+            agent=math_peer_graph,
+            description="Specialist math agent that uses MCP math tools for accurate computation.",
+        )
+    }
+
+    # ---------------------------------------------------------------------
+    # 2) Build the main agent and attach cross-agent tools
+    # ---------------------------------------------------------------------
+    main_graph, loader = await build_deep_agent(
+        servers=servers,
+        model=main_model,
+        instructions=(
+            "You are a helpful orchestrator. Prefer calling tools rather than guessing. "
+            "If the task is mathematical, DELEGATE to the math peer via the tool "
+            "'ask_agent_mathpeer'. If multiple peers exist, you may also use "
+            "'broadcast_to_agents' to compare answers."
+        ),
+        trace_tools=True,        # See tool invocations from the main agent (including cross-agent tools)
+        cross_agents=peers,      # <-- Attach the peer(s)
+    )
+
+    # ---------------------------------------------------------------------
+    # 3) Show discovered tools (MCP) + cross-agent tools
+    # ---------------------------------------------------------------------
+    infos = await loader.list_tool_info()
+    infos = list(infos) if infos else []
+
+    mcp_table = Table(title="Discovered MCP Tools", show_lines=True)
+    mcp_table.add_column("Name", style="cyan", no_wrap=True)
+    mcp_table.add_column("Description", style="green")
+    if infos:
+        for t in infos:
+            mcp_table.add_row(t.name, t.description or "-")
+    else:
+        mcp_table.add_row("— none —", "No tools discovered (is your MCP server running?)")
+    console.print(mcp_table)
+
+    cross_table = Table(title="Cross-Agent Tools (exposed on MAIN agent)", show_lines=True)
+    cross_table.add_column("Tool", style="cyan", no_wrap=True)
+    cross_table.add_column("What it does", style="green")
+    # One per peer:
+    for name in peers:
+        cross_table.add_row(f"ask_agent_{name}", f"Ask the '{name}' peer for help.")
+    # Broadcast tool is always added by make_cross_agent_tools in our integration
+    cross_table.add_row("broadcast_to_agents", "Ask multiple peers in parallel and collect answers.")
+    console.print(cross_table)
+
+    # ---------------------------------------------------------------------
+    # 4) Run a single-turn query that should trigger delegation
+    # ---------------------------------------------------------------------
+    query = (
+        "A rectangle is width 3.5 and length 6.2. "
+        "Compute area and perimeter, then add 17^2 to the sum of (area + perimeter). "
+        "Please DELEGATE to the math peer via the 'ask_agent_mathpeer' tool and show brief steps."
+    )
+    console.print(Panel.fit(query, title="User Query (expects cross-agent delegation)", style="bold magenta"))
+
+    result = await main_graph.ainvoke({"messages": [{"role": "user", "content": query}]})
+    final_text = _extract_final_answer(result)
+    console.print(Panel(final_text or "(no content)", title="Final LLM Answer", style="bold green"))
+
+    # ---------------------------------------------------------------------
+    # 5) (Optional) Demonstrate broadcast to peers — with one peer it's trivial,
+    #    but we show how you'd instruct the main agent to use it.
+    # ---------------------------------------------------------------------
+    query2 = (
+        "As a quick check, consult all peers via 'broadcast_to_agents' with the message "
+        "'Compute (3 + 5) * 7 using MCP math tools.' Then summarize the responses."
+    )
+    console.print(Panel.fit(query2, title="User Query (broadcast demo)", style="bold magenta"))
+    result2 = await main_graph.ainvoke({"messages": [{"role": "user", "content": query2}]})
+    final_text2 = _extract_final_answer(result2)
+    console.print(Panel(final_text2 or "(no content)", title="Final LLM Answer (Broadcast)", style="bold green"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deepmcpagent/config.py
+++ b/src/deepmcpagent/config.py
@@ -1,18 +1,17 @@
-"""Typed server specifications and conversion helpers for FastMCP configuration."""
+""""Typed server specifications and conversion helpers for FastMCP configuration."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class _BaseServer(BaseModel):
     """Base model for server specs."""
-
-    class Config:
-        extra = "forbid"
+    # Pydantic v2 style configuration (replaces class Config)
+    model_config = ConfigDict(extra="forbid")
 
 
 class StdioServerSpec(_BaseServer):

--- a/src/deepmcpagent/cross_agent.py
+++ b/src/deepmcpagent/cross_agent.py
@@ -1,0 +1,268 @@
+# deepmcpagent/cross_agent.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Iterable, Sequence, Callable, cast
+
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field, PrivateAttr
+
+
+# -----------------------------
+# Public API surface
+# -----------------------------
+
+@dataclass(frozen=True)
+class CrossAgent:
+    """Wrap a runnable agent (LangGraph/DeepAgents) to expose it as a tool.
+
+    Attributes:
+        agent: A Runnable that accepts {"messages": [...]} and returns a result.
+        description: One-line human description used in tool docs.
+    """
+
+    agent: Runnable[Any, Any]
+    description: str = ""
+
+
+def make_cross_agent_tools(
+    peers: Mapping[str, CrossAgent],
+    *,
+    tool_name_prefix: str = "ask_agent_",
+    include_broadcast: bool = True,
+) -> list[BaseTool]:
+    """Create LangChain tools that allow an agent to ask its peers questions.
+
+    For each peer, we create a tool `{tool_name_prefix}{peer_name}` that takes a
+    text message (plus optional context) and returns the peer's final text.
+
+    Optionally, we also add a `broadcast_to_agents` tool to consult multiple peers
+    in parallel and return a dict of peer->answer.
+    """
+    if not peers:
+        return []
+
+    def _best_text(result: Any) -> str:
+        """Best-effort extraction of a final text answer from common executors."""
+        try:
+            if isinstance(result, dict) and "messages" in result and result["messages"]:
+                last = result["messages"][-1]
+                content = getattr(last, "content", None)
+                if isinstance(content, str) and content:
+                    return content
+                if isinstance(content, list) and content and isinstance(content[0], dict):
+                    return cast(str, content[0].get("text") or str(content))
+                return str(last)
+            return str(result)
+        except Exception:
+            return str(result)
+
+    out: list[BaseTool] = []
+
+    # Per-agent ask tools
+    for name, spec in peers.items():
+        out.append(
+            _AskAgentTool(
+                name=f"{tool_name_prefix}{name}",
+                description=(f"Ask peer agent '{name}' for help. " + (spec.description or "")).strip(),
+                target=spec.agent,
+                extract=_best_text,
+            )
+        )
+
+    # Optional broadcast tool
+    if include_broadcast:
+        out.append(
+            _BroadcastTool(
+                name="broadcast_to_agents",
+                description=(
+                    "Ask multiple peer agents the same question in parallel and "
+                    "return each peer's final answer."
+                ),
+                peers=peers,
+                extract=_best_text,
+            )
+        )
+
+    return out
+
+
+# -----------------------------
+# Tool implementations
+# -----------------------------
+
+class _AskArgs(BaseModel):
+    message: str = Field(..., description="Message to send to the peer agent.")
+    context: str | None = Field(
+        None,
+        description=(
+            "Optional additional context from the caller (e.g., hints, partial "
+            "results, constraints)."
+        ),
+    )
+    timeout_s: float | None = Field(
+        None,
+        ge=0,
+        description="Optional timeout in seconds for the peer agent call.",
+    )
+
+
+class _AskAgentTool(BaseTool):
+    """Tool that forwards a question to a specific peer agent."""
+
+    name: str
+    description: str
+    # Pydantic v2 requires a type annotation for field overrides.
+    args_schema: type[BaseModel] = _AskArgs
+
+    _target: Runnable[Any, Any] = PrivateAttr()
+    _extract: Callable[[Any], str] = PrivateAttr()
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        target: Runnable[Any, Any],
+        extract: Callable[[Any], str],
+    ) -> None:
+        super().__init__(name=name, description=description)
+        self._target = target
+        self._extract = extract
+
+    async def _arun(
+        self,
+        *,
+        message: str,
+        context: str | None = None,
+        timeout_s: float | None = None,
+    ) -> str:
+        payload: list[dict[str, Any]] = []
+        # Put context first to bias some executors that read system first
+        if context:
+            payload.append({"role": "system", "content": f"Caller context: {context}"})
+        payload.append({"role": "user", "content": message})
+
+        async def _call() -> Any:
+            return await self._target.ainvoke({"messages": payload})
+
+        if timeout_s and timeout_s > 0:
+            import anyio
+            with anyio.move_on_after(timeout_s) as scope:
+                res = await _call()
+                if scope.cancel_called:  # rare
+                    return "Timed out waiting for peer agent reply."
+        else:
+            res = await _call()
+
+        return self._extract(res)
+
+    # BaseTool is abstract and requires a sync path, even if you mainly use async.
+    def _run(
+        self,
+        *,
+        message: str,
+        context: str | None = None,
+        timeout_s: float | None = None,
+    ) -> str:  # pragma: no cover (usually unused in async apps)
+        import anyio
+        return anyio.run(
+            lambda: self._arun(message=message, context=context, timeout_s=timeout_s)
+        )
+
+
+class _BroadcastArgs(BaseModel):
+    message: str = Field(..., description="Message to send to all/selected peers.")
+    peers: Sequence[str] | None = Field(
+        None, description="Optional subset of peer names. If omitted, use all peers."
+    )
+    timeout_s: float | None = Field(
+        None, ge=0, description="Optional timeout per peer call in seconds."
+    )
+
+
+class _BroadcastTool(BaseTool):
+    """Ask multiple peer agents in parallel and return a mapping of answers."""
+
+    name: str
+    description: str
+    # Pydantic v2 requires a type annotation for field overrides.
+    args_schema: type[BaseModel] = _BroadcastArgs
+
+    _peers: Mapping[str, CrossAgent] = PrivateAttr()
+    _extract: Callable[[Any], str] = PrivateAttr()
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        peers: Mapping[str, CrossAgent],
+        extract: Callable[[Any], str],
+    ) -> None:
+        super().__init__(name=name, description=description)
+        self._peers = peers
+        self._extract = extract
+
+    async def _arun(
+        self,
+        *,
+        message: str,
+        peers: Sequence[str] | None = None,
+        timeout_s: float | None = None,
+    ) -> dict[str, str]:
+        selected: Iterable[tuple[str, CrossAgent]]
+        if peers:
+            missing = [p for p in peers if p not in self._peers]
+            if missing:
+                raise ValueError(f"Unknown peer(s): {', '.join(missing)}")
+            selected = [(p, self._peers[p]) for p in peers]
+        else:
+            selected = list(self._peers.items())
+
+        import anyio
+
+        results: dict[str, str] = {}
+
+        async def _one(name: str, target: Runnable[Any, Any]) -> None:
+            async def _call() -> Any:
+                return await target.ainvoke(
+                    {"messages": [{"role": "user", "content": message}]}
+                )
+
+            if timeout_s and timeout_s > 0:
+                with anyio.move_on_after(timeout_s) as scope:
+                    try:
+                        res = await _call()
+                        if scope.cancel_called:
+                            results[name] = "Timed out"
+                            return
+                        results[name] = self._extract(res)
+                    except Exception as exc:  # keep broadcast resilient
+                        results[name] = f"Error: {exc}"
+            else:
+                try:
+                    res = await _call()
+                    results[name] = self._extract(res)
+                except Exception as exc:
+                    results[name] = f"Error: {exc}"
+
+        # Using TaskGroup for compatibility across anyio versions
+        async with anyio.create_task_group() as tg:
+            for n, s in selected:
+                tg.start_soon(_one, n, s.agent)
+
+        return results
+
+    def _run(
+        self,
+        *,
+        message: str,
+        peers: Sequence[str] | None = None,
+        timeout_s: float | None = None,
+    ) -> dict[str, str]:  # pragma: no cover (usually unused in async apps)
+        import anyio
+        return anyio.run(
+            lambda: self._arun(message=message, peers=peers, timeout_s=timeout_s)
+        )

--- a/src/deepmcpagent/cross_agent.py
+++ b/src/deepmcpagent/cross_agent.py
@@ -1,4 +1,48 @@
 # deepmcpagent/cross_agent.py
+"""
+Cross-agent communication utilities for DeepMCPAgent.
+
+Expose other in-process agents (“peers”) as standard LangChain tools so a
+primary (caller) agent can *delegate* to them during planning/execution.
+
+Tools provided
+    - Per-peer ask tool  →  ``ask_agent_<name>``
+      Forward one message (plus optional caller context) to a single peer and
+      return the peer’s final text.
+
+    - Broadcast tool     →  ``broadcast_to_agents``
+      Send the same message to multiple peers in parallel and return a mapping
+      of peer → final text. Timeouts/errors are captured per peer so one slow
+      or failing peer does not fail the whole call.
+
+Notes:
+    - No new infrastructure is required. Peers are just in-process LangChain
+      ``Runnable`` graphs (e.g., a DeepAgents loop or a LangGraph prebuilt
+      executor returned by :func:`deepmcpagent.agent.build_deep_agent`).
+    - Both tool classes implement async and sync execution paths (``_arun`` and
+      ``_run``) to satisfy ``BaseTool``’s interface.
+    - Optional per-call timeouts use ``anyio.move_on_after``.
+    - The “final text” is extracted from common agent result shapes. If your
+      peer returns a custom structure, adapt upstream or post-process the
+      returned string.
+
+Examples:
+    Build a peer agent and attach it to a main agent as a tool:
+
+    >>> from deepmcpagent.agent import build_deep_agent
+    >>> from deepmcpagent.cross_agent import CrossAgent
+    >>>
+    >>> peer_graph, _ = await build_deep_agent(servers=..., model="openai:gpt-4o-mini")
+    >>> main_graph, _ = await build_deep_agent(
+    ...     servers=...,
+    ...     model="openai:gpt-4.1",
+    ...     cross_agents={"researcher": CrossAgent(agent=peer_graph, description="Web research")}
+    ... )
+    >>> # Now the main agent can call:
+    >>> #   - ask_agent_researcher(message=..., context?=..., timeout_s?=...)
+    >>> #   - broadcast_to_agents(message=..., peers?=[...], timeout_s?=...)
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -15,11 +59,20 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 @dataclass(frozen=True)
 class CrossAgent:
-    """Wrap a runnable agent (LangGraph/DeepAgents) to expose it as a tool.
+    """Metadata wrapper for a peer agent to be exposed as a tool.
+
+    The wrapper is descriptive only. Behavior is implemented by tools produced
+    via :func:`make_cross_agent_tools`.
 
     Attributes:
-        agent: A Runnable that accepts {"messages": [...]} and returns a result.
-        description: One-line human description used in tool docs.
+        agent: A runnable agent (e.g., LangGraph or DeepAgents) that accepts
+            ``{"messages": [...]}`` and returns a result consumable by the
+            built-in “best final text” extractor.
+        description: One-line human description used in tool docs to help the
+            calling agent decide when to delegate.
+
+    Examples:
+        >>> cross = CrossAgent(agent=peer_graph, description="Accurate math")
     """
 
     agent: Runnable[Any, Any]
@@ -32,19 +85,49 @@ def make_cross_agent_tools(
     tool_name_prefix: str = "ask_agent_",
     include_broadcast: bool = True,
 ) -> list[BaseTool]:
-    """Create LangChain tools that allow an agent to ask its peers questions.
+    """Create LangChain tools for cross-agent communication.
 
-    For each peer, we create a tool `{tool_name_prefix}{peer_name}` that takes a
-    text message (plus optional context) and returns the peer's final text.
+    For each peer, a tool named ``f"{tool_name_prefix}{peer_name}"`` is created.
+    Optionally, a ``broadcast_to_agents`` tool is added to fan-out questions to
+    multiple peers concurrently.
 
-    Optionally, we also add a `broadcast_to_agents` tool to consult multiple peers
-    in parallel and return a dict of peer->answer.
+    Args:
+        peers: Mapping of peer name → :class:`CrossAgent`. The name becomes part
+            of the tool id (e.g., ``ask_agent_mathpeer``).
+        tool_name_prefix: Prefix used for each per-peer ask tool. Defaults to
+            ``"ask_agent_"``.
+        include_broadcast: When ``True`` (default), also include the group
+            fan-out tool ``broadcast_to_agents``.
+
+    Returns:
+        list[BaseTool]: A list of fully constructed tools ready to be appended
+        to the caller agent’s toolset.
+
+    Notes:
+        Construction does not contact peers; errors (e.g., network) surface at
+        call time during execution of the generated tools.
+
+    Examples:
+        >>> tools = make_cross_agent_tools({
+        ...     "researcher": CrossAgent(agent=peer_graph, description="Web research")
+        ... })
+        >>> # Attach `tools` alongside your MCP-discovered tools when building the agent.
     """
     if not peers:
         return []
 
     def _best_text(result: Any) -> str:
-        """Best-effort extraction of a final text answer from common executors."""
+        """Extract a final text answer from common agent result shapes.
+
+        Looks for a LangGraph-like ``{"messages": [...]}`` structure; otherwise
+        falls back to ``str(result)``.
+
+        Args:
+            result: The raw result returned by a peer agent.
+
+        Returns:
+            str: Best-effort final text response.
+        """
         try:
             if isinstance(result, dict) and "messages" in result and result["messages"]:
                 last = result["messages"][-1]
@@ -93,12 +176,23 @@ def make_cross_agent_tools(
 # -----------------------------
 
 class _AskArgs(BaseModel):
+    """Arguments for per-peer ask tools (``ask_agent_<name>``).
+
+    Attributes:
+        message: The user-level message to forward to the peer agent.
+        context: Optional caller context (constraints, partial results, style
+            guide). If provided, it is inserted first as a *system* message to
+            bias many executors.
+        timeout_s: Optional timeout (seconds). If exceeded, the tool returns
+            ``"Timed out waiting for peer agent reply."`` instead of raising.
+    """
+
     message: str = Field(..., description="Message to send to the peer agent.")
     context: str | None = Field(
         None,
         description=(
             "Optional additional context from the caller (e.g., hints, partial "
-            "results, constraints)."
+            "results, or constraints)."
         ),
     )
     timeout_s: float | None = Field(
@@ -109,7 +203,23 @@ class _AskArgs(BaseModel):
 
 
 class _AskAgentTool(BaseTool):
-    """Tool that forwards a question to a specific peer agent."""
+    """Tool that forwards a question to a specific peer agent.
+
+    This tool wraps a peer :class:`~langchain_core.runnables.Runnable` and
+    returns the peer’s *final text* using a best-effort extractor.
+
+    Attributes:
+        name: Tool identifier (e.g., ``ask_agent_researcher``).
+        description: Human description to guide the caller agent’s planning.
+        args_schema: Pydantic model describing accepted keyword args.
+
+    Notes:
+        - Async-first: prefer ``_arun``; a sync shim (``_run``) is provided to
+          satisfy the abstract base class and support sync-only executors.
+        - The peer is invoked with a ChatML-like payload:
+          ``{"messages": [{"role": "...", "content": "..."}]}``.
+
+    """
 
     name: str
     description: str
@@ -127,6 +237,14 @@ class _AskAgentTool(BaseTool):
         target: Runnable[Any, Any],
         extract: Callable[[Any], str],
     ) -> None:
+        """Initialize the ask tool.
+
+        Args:
+            name: Tool identifier.
+            description: Human description for planning.
+            target: The peer agent runnable to call.
+            extract: Function that extracts the final text from peer results.
+        """
         super().__init__(name=name, description=description)
         self._target = target
         self._extract = extract
@@ -138,6 +256,21 @@ class _AskAgentTool(BaseTool):
         context: str | None = None,
         timeout_s: float | None = None,
     ) -> str:
+        """Asynchronously forward a message to the peer agent.
+
+        Args:
+            message: The message to forward (becomes a user message).
+            context: Optional caller context, sent first as a system message.
+            timeout_s: Optional timeout in seconds for the peer call.
+
+        Returns:
+            str: The peer agent’s best-effort final text answer, or a timeout
+            message if the deadline is exceeded.
+
+        Raises:
+            Exception: Propagates exceptions raised by the peer call (network or
+            executor failures). On timeout, returns a string instead of raising.
+        """
         payload: list[dict[str, Any]] = []
         # Put context first to bias some executors that read system first
         if context:
@@ -158,7 +291,6 @@ class _AskAgentTool(BaseTool):
 
         return self._extract(res)
 
-    # BaseTool is abstract and requires a sync path, even if you mainly use async.
     def _run(
         self,
         *,
@@ -166,6 +298,16 @@ class _AskAgentTool(BaseTool):
         context: str | None = None,
         timeout_s: float | None = None,
     ) -> str:  # pragma: no cover (usually unused in async apps)
+        """Synchronous shim that delegates to :meth:`_arun`.
+
+        Args:
+            message: The message to forward (becomes a user message).
+            context: Optional caller context, sent first as a system message.
+            timeout_s: Optional timeout in seconds for the peer call.
+
+        Returns:
+            str: The peer agent’s best-effort final text answer (or timeout text).
+        """
         import anyio
         return anyio.run(
             lambda: self._arun(message=message, context=context, timeout_s=timeout_s)
@@ -173,6 +315,16 @@ class _AskAgentTool(BaseTool):
 
 
 class _BroadcastArgs(BaseModel):
+    """Arguments for the broadcast tool (``broadcast_to_agents``).
+
+    Attributes:
+        message: The shared message sent to all (or a subset of) peers.
+        peers: Optional subset of peer names to consult. If omitted, all
+            registered peers are consulted.
+        timeout_s: Optional per-peer timeout in seconds. Affected peers return
+            ``"Timed out"`` in the result mapping.
+    """
+
     message: str = Field(..., description="Message to send to all/selected peers.")
     peers: Sequence[str] | None = Field(
         None, description="Optional subset of peer names. If omitted, use all peers."
@@ -183,7 +335,19 @@ class _BroadcastArgs(BaseModel):
 
 
 class _BroadcastTool(BaseTool):
-    """Ask multiple peer agents in parallel and return a mapping of answers."""
+    """Ask multiple peer agents in parallel and return a mapping of answers.
+
+    Each selected peer is invoked concurrently. Timeouts and exceptions are
+    captured **per peer** so the overall call remains resilient.
+
+    Attributes:
+        name: Tool identifier (``broadcast_to_agents``).
+        description: Human description for planning.
+        args_schema: Pydantic model describing accepted keyword args.
+
+    Notes:
+        Uses ``anyio.create_task_group`` for compatibility across anyio versions.
+    """
 
     name: str
     description: str
@@ -201,6 +365,14 @@ class _BroadcastTool(BaseTool):
         peers: Mapping[str, CrossAgent],
         extract: Callable[[Any], str],
     ) -> None:
+        """Initialize the broadcast tool.
+
+        Args:
+            name: Tool identifier.
+            description: Human description for planning.
+            peers: Mapping of peer name → :class:`CrossAgent`.
+            extract: Function that extracts the final text from peer results.
+        """
         super().__init__(name=name, description=description)
         self._peers = peers
         self._extract = extract
@@ -212,6 +384,21 @@ class _BroadcastTool(BaseTool):
         peers: Sequence[str] | None = None,
         timeout_s: float | None = None,
     ) -> dict[str, str]:
+        """Asynchronously consult multiple peers in parallel.
+
+        Args:
+            message: The message forwarded to each selected peer.
+            peers: Optional subset of peer names to target. If ``None``, uses all.
+            timeout_s: Optional timeout in seconds applied per peer call.
+
+        Returns:
+            dict[str, str]: Mapping of ``peer_name`` → final text. Peers that
+            exceed the timeout return ``"Timed out"``. Peers that raise an
+            exception return ``"Error: <message>"``.
+
+        Raises:
+            ValueError: If any requested peer name is unknown.
+        """
         selected: Iterable[tuple[str, CrossAgent]]
         if peers:
             missing = [p for p in peers if p not in self._peers]
@@ -262,6 +449,16 @@ class _BroadcastTool(BaseTool):
         peers: Sequence[str] | None = None,
         timeout_s: float | None = None,
     ) -> dict[str, str]:  # pragma: no cover (usually unused in async apps)
+        """Synchronous shim that delegates to :meth:`_arun`.
+
+        Args:
+            message: The message forwarded to each selected peer.
+            peers: Optional subset of peer names to target. If ``None``, uses all.
+            timeout_s: Optional timeout in seconds applied per peer call.
+
+        Returns:
+            dict[str, str]: Mapping of ``peer_name`` → final text (or timeout/error text).
+        """
         import anyio
         return anyio.run(
             lambda: self._arun(message=message, peers=peers, timeout_s=timeout_s)


### PR DESCRIPTION
This PR adds **Cross Agent Communication** to DeepMCPAgent, enabling one agent to delegate work to other in-process agents via normal tool calls. Each peer agent is exposed as a LangChain tool (`ask_agent_<name>`) plus an optional fan-out tool (`broadcast_to_agents`) for parallel consultation. No extra infra or new MCP servers required.