### PR TITLE
feat(identity): Agent Identity subsystem — federated authentication via WIF (Entra, AWS, GCP, SPIFFE, OIDC)

### DIFF
--- a/.github/workflows/identity-integration.yml
+++ b/.github/workflows/identity-integration.yml
@@ -1,0 +1,76 @@
+# Agent Identity — live federation integration test.
+#
+# Runs the examples/identity/github_actions example end-to-end: it mints a real
+# GitHub OIDC token, exchanges it for an Anthropic access token via a Workload
+# Identity Federation rule, and drives one agent invocation — with NO
+# ANTHROPIC_API_KEY.
+#
+# MANUAL SETUP REQUIRED (one time, by a maintainer) for the live test to run:
+#   1. In the Anthropic Console, create a Workload Identity Federation rule:
+#        issuer:   https://token.actions.githubusercontent.com
+#        audience: https://api.anthropic.com
+#        subject:  repo:OWNER/REPO:ref:refs/heads/main  (or your chosen ref)
+#   2. Add these as repository *variables* (Settings → Secrets and variables →
+#      Actions → Variables) — they are identifiers, not secrets:
+#        ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+#        ANTHROPIC_SERVICE_ACCOUNT_ID
+#
+# Until that variable is set, this workflow SKIPS the live test (with a notice)
+# rather than failing — so it stays green on forks and unconfigured repos.
+# Note: pull requests from forks do not receive an OIDC token, so the live test
+# runs on same-repo pushes/PRs and workflow_dispatch only.
+
+name: Identity Integration
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # REQUIRED to mint the OIDC token
+  contents: read
+
+jobs:
+  federated-auth:
+    name: Live federation test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install promptise (from source)
+        run: pip install -e .
+
+      - name: Check federation configuration
+        id: cfg
+        env:
+          FED: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+        run: |
+          if [ -z "$FED" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_FEDERATION_RULE_ID repo variable not set — skipping the live federation test. See examples/identity/github_actions for setup."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint the GitHub OIDC token
+        if: steps.cfg.outputs.configured == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('https://api.anthropic.com')
+            core.exportVariable('GITHUB_OIDC_TOKEN', token)
+
+      - name: Run the federated agent example
+        if: steps.cfg.outputs.configured == 'true'
+        env:
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+        run: python examples/identity/github_actions/script.py

--- a/docs/api/identity.md
+++ b/docs/api/identity.md
@@ -1,0 +1,203 @@
+# Agent Identity API Reference
+
+Federated, zero-static-credential authentication — every public class, factory,
+and exception across `promptise.identity`.
+
+For concepts and setup, start with the [Agent Identity overview](../identity/overview.md).
+
+## Public class
+
+### AgentIdentity
+
+The entire user-facing surface. Construct one with a factory classmethod
+(`from_entra`, `from_aws`, `from_gcp`, `from_spiffe`, `from_oidc`) or
+`auto()`, then call `get_token()` / `get_auth_header()` or pass it to
+`build_agent(identity=...)`.
+
+::: promptise.identity.AgentIdentity
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - from_entra
+        - from_aws
+        - from_gcp
+        - from_spiffe
+        - from_oidc
+        - auto
+        - get_token
+        - get_auth_header
+        - get_upstream_jwt
+        - provider
+        - provider_name
+        - federation_rule_id
+        - organization_id
+        - service_account_id
+        - workspace_id
+
+---
+
+## Token model
+
+### MintedToken
+
+An immutable minted Anthropic access token with monotonic expiry and the
+two-tier refresh helpers. The module also exposes
+`ADVISORY_REFRESH_BUFFER_SECONDS` (120) and
+`MANDATORY_REFRESH_BUFFER_SECONDS` (30).
+
+::: promptise.identity.MintedToken
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Provider base classes
+
+For advanced use and custom subclassing.
+
+### IdentityProvider
+
+::: promptise.identity.IdentityProvider
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - get_token
+        - get_auth_header
+        - provider_name
+
+### FileTokenProvider
+
+::: promptise.identity.FileTokenProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+### CallableTokenProvider
+
+::: promptise.identity.CallableTokenProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Concrete providers
+
+### Microsoft Entra ID
+
+::: promptise.identity.EntraManagedIdentityProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.EntraProjectedTokenProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+### AWS IAM
+
+::: promptise.identity.AwsStsProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.AwsEksProjectedProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+### Google Cloud
+
+::: promptise.identity.GcpMetadataProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+### SPIFFE / SPIRE
+
+::: promptise.identity.SpiffeFileProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.SpiffeSdkProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+### Generic OIDC
+
+::: promptise.identity.OidcFileProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.OidcCallableProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Exceptions
+
+All derive from `IdentityError`.
+
+::: promptise.identity.IdentityError
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.TokenAcquisitionError
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.TokenExchangeError
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.ProviderConfigError
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.CredentialPrecedenceError
+    options:
+      show_source: false
+      heading_level: 4
+
+::: promptise.identity.PlatformDetectionError
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Internals
+
+The exchange engine and platform detection — useful when debugging or building
+a custom provider.
+
+### exchange_jwt_for_anthropic_token
+
+The RFC 7523 `jwt-bearer` exchange every provider funnels through.
+
+::: promptise.identity._core.exchange.exchange_jwt_for_anthropic_token
+    options:
+      show_source: false
+      heading_level: 4
+
+### detect_platform
+
+The environment-marker detection behind `AgentIdentity.auto()`.
+
+::: promptise.identity._internal.detect.detect_platform
+    options:
+      show_source: false
+      heading_level: 4

--- a/docs/identity/architecture.md
+++ b/docs/identity/architecture.md
@@ -1,0 +1,118 @@
+# Architecture
+
+Agent Identity is a thin, layered subsystem. User code touches exactly one
+class — `AgentIdentity` — and everything below it is a provider, a cache, and a
+single RFC 7523 exchange call.
+
+## Request path
+
+```mermaid
+flowchart TD
+    U["User code<br/>build_agent(model=…, identity=AgentIdentity.from_aws())"]
+    AI["AgentIdentity (public class)<br/>forwards get_token / get_auth_header / get_upstream_jwt"]
+    IP["IdentityProvider (abstract base)<br/>holds the cached MintedToken<br/>thread-safe via threading.Lock<br/>two-tier refresh (advisory −120s, mandatory −30s)"]
+    ACQ["_acquire_upstream_jwt() (abstract)<br/>implemented by each concrete provider"]
+    EX["exchange_jwt_for_anthropic_token()<br/>POST /v1/oauth/token<br/>RFC 7523 jwt-bearer grant → MintedToken"]
+    FILE["File provider<br/>re-reads on every refresh"]
+    CALL["Callable provider"]
+    PS["Provider-specific acquisition<br/>• boto3 STS (AWS)<br/>• IMDS HTTP (Entra)<br/>• Metadata server (GCP)<br/>• Workload API (SPIFFE)<br/>• User callable (OIDC)"]
+    DISK["File on disk<br/>• projected token (K8s)<br/>• spiffe-helper output<br/>• $AZURE_FEDERATED_TOKEN_FILE (AKS)"]
+    ANTH["Anthropic /v1/oauth/token"]
+
+    U --> AI --> IP
+    IP --> ACQ
+    IP --> EX
+    EX --> ANTH
+    ACQ --> FILE
+    ACQ --> CALL
+    CALL --> PS
+    FILE --> DISK
+```
+
+The framework owns only two things: the **exchange step** and the **cache**.
+Every provider uses the platform's native SDK or metadata service to obtain the
+upstream JWT — nothing here re-implements an identity provider.
+
+## Token lifecycle
+
+A minted token is a small immutable record (`MintedToken`) carrying the access
+token, its type, and a monotonic expiry. `get_token()` runs a two-tier refresh
+under a `threading.Lock`, so concurrent callers collapse into a single exchange:
+
+```mermaid
+flowchart TD
+    A["get_token()"] --> B{cached token?}
+    B -- no --> R["mandatory refresh<br/>(failure raises)"]
+    B -- yes --> C{"≤ 30s to expiry?<br/>(mandatory window)"}
+    C -- yes --> R
+    C -- no --> D{"≤ 120s to expiry?<br/>(advisory window)"}
+    D -- yes --> E["try refresh;<br/>on failure log WARNING<br/>and keep the cached token"]
+    D -- no --> F["return cached token"]
+    R --> G["return fresh token"]
+    E --> G
+```
+
+- **Mandatory window** (`MANDATORY_REFRESH_BUFFER_SECONDS` = 30s, or no token):
+  a refresh is required; any failure propagates as
+  [`TokenAcquisitionError`](security.md#errors) or `TokenExchangeError`.
+- **Advisory window** (`ADVISORY_REFRESH_BUFFER_SECONDS` = 120s): a refresh is
+  *attempted*; if it fails the still-valid cached token is returned and a
+  warning is logged.
+
+Expiry uses `time.monotonic()`, not wall-clock time, so the logic is immune to
+clock skew and NTP steps. The cache is **process-local** by design — minted
+tokens are never shared across processes (see [Security](security.md)).
+
+## Auto-detection
+
+`AgentIdentity.auto()` picks a provider from environment markers, in a fixed
+precedence order, with **no metadata-server probe** (it is fast and works
+offline):
+
+| Order | Platform | Markers |
+| --- | --- | --- |
+| 1 | Entra | `AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID` |
+| 2 | AWS | `AWS_LAMBDA_FUNCTION_NAME`, `AWS_EXECUTION_ENV`, `EKS_POD_NAME`, `AWS_WEB_IDENTITY_TOKEN_FILE` |
+| 3 | GCP | `GOOGLE_CLOUD_PROJECT`, `K_SERVICE`, `GCE_METADATA_IP` |
+| 4 | SPIFFE | `SPIFFE_ENDPOINT_SOCKET` |
+
+If a workload sets markers for more than one platform, the first match wins. If
+none match, `auto()` raises [`PlatformDetectionError`](security.md#errors)
+naming the explicit `from_*` factories as the fallback.
+
+## `build_agent()` integration
+
+When you pass `identity=` to `build_agent()` with a **model id string**, the
+agent's own Anthropic calls are authenticated with the federated token:
+
+- The minted token is a *bearer* token, so it is placed in the `Authorization`
+  header (`Authorization: Bearer sk-ant-oat01-…`); no `x-api-key` is sent.
+- If `ANTHROPIC_API_KEY` is also set, `build_agent()` raises
+  [`CredentialPrecedenceError`](security.md#errors) rather than let the static
+  key silently shadow the federated identity.
+- The identity is exposed as `agent.identity`, so MCP tools and downstream
+  calls can mint authenticated headers with `agent.identity.get_auth_header()`.
+
+The token is resolved when the model is built. A long-lived agent that outlives
+the token lifetime should be rebuilt (or call `agent.identity.get_token()` for a
+fresh token in its own outbound calls).
+
+!!! note "Anthropic SDK versions"
+    The integration injects the bearer token at the model-construction layer
+    (via LangChain `init_chat_model`) because it works on the SDK versions
+    Promptise targets today. If a future Anthropic SDK ships a first-class
+    workload-identity credential type, the agent's own calls can move onto it
+    without any change to the `AgentIdentity` public surface.
+
+## Audit-log enrichment (integration contract)
+
+When an `AgentIdentity` is attached to an agent, the Security Guardrails audit
+log can stamp every entry with two extra fields:
+
+- `identity.provider` — the provider's `provider_name` (e.g. `aws-sts`).
+- `identity.service_account_id` — the federated service account id.
+
+These are available from `agent.identity.provider_name` and
+`agent.identity.service_account_id`. Wiring them into the audit-log writer is a
+cross-subsystem change owned by Guardrails and is tracked as a follow-up; the
+contract above is the integration point.

--- a/docs/identity/migration.md
+++ b/docs/identity/migration.md
@@ -1,0 +1,84 @@
+# Migration
+
+Moving an existing agent from a static `ANTHROPIC_API_KEY` to federated identity
+is a one-line code change plus an environment change. This page shows how to do
+it without downtime.
+
+## Before
+
+```python
+# ANTHROPIC_API_KEY is set in the environment; build_agent reads it implicitly.
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+)
+```
+
+## After
+
+```python
+from promptise.identity import AgentIdentity
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.auto(),   # or from_aws(), from_gcp(), …
+)
+```
+
+## Step-by-step, zero downtime
+
+1. **Register the federation rule** in the Anthropic Console for the platform
+   your workload runs on, and record the `fdrl_…`, organization UUID, and
+   `svac_…` identifiers. (See the [provider pages](../identity/overview.md#supported-providers)
+   for per-platform Console setup.)
+
+2. **Verify the exchange out-of-band**, while the old key is still in place.
+   Mint a token in a throwaway script and confirm it succeeds:
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    identity = AgentIdentity.auto()
+    print(identity.provider_name)
+    token = identity.get_token()
+    assert token.startswith("sk-ant-oat01-")
+    print("federation works")
+    ```
+
+    If this raises, fix the federation rule before touching the running agent —
+    the live agent is still healthy on its API key.
+
+3. **Add `identity=` to `build_agent()`** and deploy. Because the credential
+   precedence guard refuses to run with *both* an identity and
+   `ANTHROPIC_API_KEY`, do this together with step 4.
+
+4. **Unset `ANTHROPIC_API_KEY`** in the same deploy. The guard exists precisely
+   so you cannot accidentally ship a config where the static key silently
+   shadows the federated identity:
+
+    ```text
+    CredentialPrecedenceError: Both an AgentIdentity and ANTHROPIC_API_KEY are
+    configured. The static API key would silently shadow the federated identity.
+    Either unset ANTHROPIC_API_KEY or remove the identity= argument.
+    ```
+
+5. **Roll back instantly if needed.** Reverting is symmetric: remove the
+   `identity=` argument and restore `ANTHROPIC_API_KEY`. No data migration, no
+   token state to clean up — the cache is in-memory and per-process.
+
+## Gradual rollout across a fleet
+
+`AgentIdentity.auto()` reads platform environment markers, so the *same image*
+can roll out to mixed platforms and each instance picks the right provider.
+Combined with a feature flag around the `identity=` argument, you can canary one
+deployment, watch the audit log for the `identity.provider` field, and expand.
+
+## Things that do not change
+
+- Your model string, MCP servers, memory, guardrails, and every other
+  `build_agent()` argument are untouched.
+- Downstream MCP tools keep working; they gain the *option* of calling
+  `agent.identity.get_auth_header()` for authenticated outbound requests.
+- Cost, latency, and the agent's behavior are unchanged — only the
+  authentication mechanism moved.

--- a/docs/identity/overview.md
+++ b/docs/identity/overview.md
@@ -1,0 +1,78 @@
+# Agent Identity
+
+**Federated authentication for AI agents — zero static credentials in agent code.**
+
+Promptise Agent Identity lets a workload prove who it is to Anthropic using the
+identity its platform *already* gives it — an AWS IAM role, a GCP service
+account, a Microsoft Entra managed identity, a SPIFFE SVID, or any OIDC issuer —
+instead of a long-lived `ANTHROPIC_API_KEY` baked into the agent.
+
+```python
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_aws(),   # zero arguments, reads the environment
+)
+```
+
+Those lines work unchanged on AWS Lambda, EKS, GKE, AKS, a Kubernetes pod with
+SPIRE, and a GitHub Actions runner. No API key is stored, printed, or committed.
+
+## How it works
+
+Every provider produces a short-lived **OIDC JWT** from the platform it runs on.
+The framework exchanges that JWT for a short-lived Anthropic access token using
+the [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)
+`urn:ietf:params:oauth:grant-type:jwt-bearer` grant, caches the token in memory,
+and refreshes it transparently before it expires. The static-credential problem
+disappears: the only thing on disk is a token the platform rotates for you.
+
+See [Architecture](architecture.md) for the full request path and the
+[two-tier refresh](architecture.md#token-lifecycle) model.
+
+## When to use it
+
+- **Cloud-hosted agents.** The workload runs on a platform that issues an
+  identity (AWS/GCP/Azure/Kubernetes). You want to stop managing API keys.
+- **CI/CD agents.** GitLab CI, GitHub Actions, CircleCI, Azure DevOps — any
+  runner that mints an OIDC token per job.
+- **Zero-trust / SPIFFE environments.** A SPIRE agent already issues SVIDs to
+  your workloads.
+- **Audit requirements.** You need every action traceable to a federated
+  service account rather than a shared key.
+
+## When *not* to use it
+
+- **Local development on a laptop** with no platform identity — a plain
+  `ANTHROPIC_API_KEY` is simpler. (You can still use the
+  [OIDC env-var path](providers/oidc.md) with a token you mint by hand.)
+- **Human SSO.** This is workload-to-Claude authentication, not a workforce
+  identity solution.
+- **A credential store.** The framework holds tokens in memory only;
+  persistence is the platform's job.
+
+## Supported providers
+
+| Provider | Factory | JWT source |
+| --- | --- | --- |
+| [Microsoft Entra ID](providers/entra.md) | `AgentIdentity.from_entra()` | IMDS, or `$AZURE_FEDERATED_TOKEN_FILE` (AKS Workload Identity) |
+| [AWS IAM](providers/aws.md) | `AgentIdentity.from_aws()` | STS `GetWebIdentityToken`, or an EKS-projected token file |
+| [Google Cloud](providers/gcp.md) | `AgentIdentity.from_gcp()` | Compute metadata server identity token |
+| [SPIFFE / SPIRE](providers/spiffe.md) | `AgentIdentity.from_spiffe()` | Workload API socket, or a `spiffe-helper` file |
+| [Generic OIDC](providers/oidc.md) | `AgentIdentity.from_oidc()` | File, callable, or environment variable |
+
+Don't know which one you're on? [`AgentIdentity.auto()`](architecture.md#auto-detection)
+detects the platform from environment markers and picks for you.
+
+## Next steps
+
+- [Quickstart](quickstart.md) — a working federated agent in five minutes, with
+  no cloud account required.
+- [Architecture](architecture.md) — the exchange engine, the cache, and the
+  refresh model.
+- [Security](security.md) — the threat model and the framework's
+  secret-handling guarantees.
+- [Migration](migration.md) — move off `ANTHROPIC_API_KEY` with no downtime.

--- a/docs/identity/providers/aws.md
+++ b/docs/identity/providers/aws.md
@@ -1,0 +1,86 @@
+# AWS IAM
+
+Federate from AWS IAM. Two modes are supported and `mode="auto"` (the default)
+picks between them:
+
+- **STS** — for Lambda, EC2, ECS, and EKS. Calls STS
+  `GetWebIdentityToken` via `boto3`.
+- **EKS-projected** — for EKS pods using a projected service-account token. Reads
+  the token file (default `/var/run/secrets/anthropic.com/token`, override with
+  `$ANTHROPIC_IDENTITY_TOKEN_FILE`). Needs no `boto3`.
+
+## Prerequisites
+
+- A workload running on AWS with an attached IAM role (Lambda execution role,
+  EC2 instance profile, ECS task role, or EKS IRSA / Pod Identity).
+- **STS mode only:** `pip install promptise[identity-aws]` (adds `boto3`) and a
+  region (from the `region=` argument, `$AWS_REGION`, or `$AWS_DEFAULT_REGION`).
+- EKS-projected mode needs no extra dependency.
+
+## Anthropic Console setup
+
+Create a Workload Identity Federation rule whose issuer is AWS STS
+(`https://sts.amazonaws.com` for the web-identity token, or your EKS OIDC
+provider URL for projected tokens) and whose subject matches the IAM role / service
+account. Export the resulting identifiers as `ANTHROPIC_FEDERATION_RULE_ID`,
+`ANTHROPIC_ORGANIZATION_ID`, and `ANTHROPIC_SERVICE_ACCOUNT_ID`.
+
+## Usage
+
+=== "Auto (recommended)"
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    # EKS-projected if $ANTHROPIC_IDENTITY_TOKEN_FILE is set, else STS.
+    identity = AgentIdentity.from_aws()
+    ```
+
+=== "STS (Lambda / EC2 / ECS)"
+
+    ```python
+    identity = AgentIdentity.from_aws(
+        mode="sts",
+        region="us-east-1",       # or rely on $AWS_REGION
+    )
+    ```
+
+=== "EKS-projected"
+
+    ```python
+    identity = AgentIdentity.from_aws(
+        mode="projected",
+        # token_file defaults to $ANTHROPIC_IDENTITY_TOKEN_FILE
+        # or /var/run/secrets/anthropic.com/token
+    )
+    ```
+
+Wire it into an agent:
+
+```python
+from promptise import build_agent
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_aws(),
+)
+```
+
+## Verify
+
+```python
+identity = AgentIdentity.from_aws(mode="sts", region="us-east-1")
+print(identity.provider_name)         # aws-sts or aws-eks-projected
+assert identity.get_token().startswith("sk-ant-oat01-")
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `ProviderConfigError: … pip install promptise[identity-aws]` | STS mode selected but `boto3` is not installed. Install the extra, or use `mode="projected"`. |
+| `ProviderConfigError: AWS STS is regional …` | No region supplied. Pass `region=` or set `$AWS_REGION`. |
+| `TokenAcquisitionError: STS GetWebIdentityToken failed` | The role is not assumable from this context, or the audience is not permitted. |
+| EKS-projected: file-not-found | The projected token volume is not mounted, or `$ANTHROPIC_IDENTITY_TOKEN_FILE` points at the wrong path. |
+| `TokenExchangeError` | The Console rule's issuer/audience does not match the AWS token. |

--- a/docs/identity/providers/entra.md
+++ b/docs/identity/providers/entra.md
@@ -1,0 +1,83 @@
+# Microsoft Entra ID
+
+Federate from Microsoft Entra ID (formerly Azure AD). Two modes are supported
+and `mode="auto"` (the default) picks between them:
+
+- **IMDS** — for VM / Managed Service Identity workloads. Reads an `id_token`
+  from the Azure Instance Metadata Service.
+- **Projected token** — for AKS Workload Identity. Reads the token file Azure
+  projects into the pod at `$AZURE_FEDERATED_TOKEN_FILE`.
+
+## Prerequisites
+
+- A workload running on Azure with either a managed identity (VM/MSI) or AKS
+  Workload Identity configured.
+- `pip install promptise` — no extra dependency; Entra uses plain HTTP and the
+  projected file, no Azure SDK.
+
+## Anthropic Console setup
+
+Create a Workload Identity Federation rule whose issuer is your Entra tenant
+(`https://login.microsoftonline.com/<tenant-id>/v2.0`) and whose subject /
+audience match your managed identity or workload-identity federated credential.
+Record the `fdrl_…`, organization UUID, and `svac_…` values and export them as
+`ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_ORGANIZATION_ID`, and
+`ANTHROPIC_SERVICE_ACCOUNT_ID`.
+
+## Usage
+
+=== "Auto (recommended)"
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    # Projected mode if $AZURE_FEDERATED_TOKEN_FILE is set, else IMDS.
+    identity = AgentIdentity.from_entra()
+    ```
+
+=== "IMDS (VM / MSI)"
+
+    ```python
+    identity = AgentIdentity.from_entra(
+        mode="imds",
+        client_id="...",          # or rely on $AZURE_CLIENT_ID
+    )
+    ```
+
+=== "Projected (AKS)"
+
+    ```python
+    identity = AgentIdentity.from_entra(
+        mode="projected",
+        # token_file defaults to $AZURE_FEDERATED_TOKEN_FILE
+    )
+    ```
+
+Wire it into an agent:
+
+```python
+from promptise import build_agent
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_entra(),
+)
+```
+
+## Verify
+
+```python
+identity = AgentIdentity.from_entra()
+print(identity.provider_name)         # entra-imds or entra-projected
+assert identity.get_token().startswith("sk-ant-oat01-")
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `TokenAcquisitionError: could not reach the Azure Instance Metadata Service` | Not running on Azure, or egress to `169.254.169.254` is blocked. Use `mode="projected"` on AKS. |
+| `TokenAcquisitionError: IMDS returned HTTP …` | The `client_id` / `resource` does not match a managed identity on this VM. |
+| Projected mode: file-not-found | `$AZURE_FEDERATED_TOKEN_FILE` is unset — AKS Workload Identity is not enabled for the pod. |
+| `TokenExchangeError` | The Console federation rule's issuer/audience does not match the Entra token. |

--- a/docs/identity/providers/gcp.md
+++ b/docs/identity/providers/gcp.md
@@ -1,0 +1,68 @@
+# Google Cloud
+
+Federate from Google Cloud. A single provider reads an OIDC identity token from
+the Compute metadata server, so it works on Compute Engine, GKE, Cloud Run,
+Cloud Functions, and any other GCP runtime that exposes
+`metadata.google.internal`.
+
+The metadata identity endpoint returns the JWT as a **plain string** (not a JSON
+wrapper), so there is nothing to parse and no SDK to install.
+
+## Prerequisites
+
+- A workload running on GCP with an attached service account.
+- `pip install promptise` — no extra dependency.
+
+## Anthropic Console setup
+
+Create a Workload Identity Federation rule whose issuer is Google
+(`https://accounts.google.com`) and whose subject matches the attached service
+account. Export the resulting identifiers as `ANTHROPIC_FEDERATION_RULE_ID`,
+`ANTHROPIC_ORGANIZATION_ID`, and `ANTHROPIC_SERVICE_ACCOUNT_ID`.
+
+## Usage
+
+=== "Default service account"
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    identity = AgentIdentity.from_gcp()
+    ```
+
+=== "Specific service account"
+
+    ```python
+    identity = AgentIdentity.from_gcp(
+        service_account_email="agent@my-project.iam.gserviceaccount.com",
+    )
+    ```
+
+Wire it into an agent:
+
+```python
+from promptise import build_agent
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_gcp(),
+)
+```
+
+## Verify
+
+```python
+identity = AgentIdentity.from_gcp()
+print(identity.provider_name)         # gcp-metadata
+assert identity.get_token().startswith("sk-ant-oat01-")
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `TokenAcquisitionError: could not reach the Google Compute metadata server` | Not running on GCP compute, or egress to `metadata.google.internal` is blocked. |
+| `TokenAcquisitionError: … HTTP 404` | The named `service_account_email` is not attached to this instance, or the audience is not permitted. |
+| `TokenAcquisitionError: … empty body` | A transient metadata-server issue or a malformed audience. |
+| `TokenExchangeError` | The Console rule's issuer/audience does not match the GCP identity token. |

--- a/docs/identity/providers/oidc.md
+++ b/docs/identity/providers/oidc.md
@@ -1,0 +1,95 @@
+# Generic OIDC
+
+Federate from any standards-compliant OIDC issuer — GitLab CI, CircleCI, Azure
+DevOps, Keycloak, Authentik, Dex, or a GitHub Actions runner. This is also the
+provider to use for **local development and Docker**, because the JWT can come
+from an environment variable with no cloud account.
+
+Supply the issuer URL and **exactly one** token source:
+
+- `token_file` — a path the JWT is written to.
+- `token_fn` — a zero-argument callable that returns the JWT.
+- `token_env_var` — the name of an environment variable holding the JWT
+  (re-read on every refresh, so CI rotation is picked up).
+
+## Prerequisites
+
+- An OIDC issuer that mints a JWT for your workload (most CI systems do this per
+  job).
+- `pip install promptise` — no extra dependency.
+
+## Anthropic Console setup
+
+Create a Workload Identity Federation rule whose issuer is your OIDC provider's
+URL and whose subject / audience match the token your issuer mints. Export the
+resulting identifiers as `ANTHROPIC_FEDERATION_RULE_ID`,
+`ANTHROPIC_ORGANIZATION_ID`, and `ANTHROPIC_SERVICE_ACCOUNT_ID`.
+
+## Usage
+
+=== "Environment variable"
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    identity = AgentIdentity.from_oidc(
+        issuer="https://gitlab.com",
+        token_env_var="CI_JOB_JWT_V2",
+    )
+    ```
+
+=== "File"
+
+    ```python
+    identity = AgentIdentity.from_oidc(
+        issuer="https://token.actions.githubusercontent.com",
+        token_file="/var/run/oidc/token",
+    )
+    ```
+
+=== "Callable"
+
+    ```python
+    def mint_jwt() -> str:
+        ...  # call your issuer and return the JWT
+
+    identity = AgentIdentity.from_oidc(
+        issuer="https://keycloak.example.com/realms/agents",
+        token_fn=mint_jwt,
+    )
+    ```
+
+Wire it into an agent:
+
+```python
+from promptise import build_agent
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_oidc(
+        issuer="https://gitlab.com",
+        token_env_var="CI_JOB_JWT_V2",
+    ),
+)
+```
+
+## Verify
+
+```python
+identity = AgentIdentity.from_oidc(
+    issuer="https://gitlab.com",
+    token_env_var="CI_JOB_JWT_V2",
+)
+print(identity.provider_name)         # oidc:https://gitlab.com
+assert identity.get_token().startswith("sk-ant-oat01-")
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `ProviderConfigError: exactly one token source …` | Zero or more than one of `token_file` / `token_fn` / `token_env_var` was supplied. |
+| `TokenAcquisitionError: … environment variable … is not set` | The named env var is missing at refresh time (the CI job's token expired or was never exported). |
+| File mode: file-not-found | The issuer did not write the token, or the path is wrong. |
+| `TokenExchangeError` | The Console rule's issuer/audience does not match the OIDC token's `iss`/`aud` claims. |

--- a/docs/identity/providers/spiffe.md
+++ b/docs/identity/providers/spiffe.md
@@ -1,0 +1,82 @@
+# SPIFFE / SPIRE
+
+Federate from a SPIFFE / SPIRE deployment using a JWT-SVID. Two modes are
+supported and `mode="auto"` (the default) picks between them:
+
+- **File** — reads a JWT-SVID written to disk by `spiffe-helper`. Needs no
+  `pyspiffe`.
+- **SDK** — connects to the SPIRE agent's Workload API Unix socket via
+  `pyspiffe` and fetches a JWT-SVID for the configured audience.
+
+## Prerequisites
+
+- A workload registered with a SPIRE server, receiving SVIDs from a local SPIRE
+  agent.
+- **SDK mode only:** `pip install promptise[identity-spiffe]` (adds `pyspiffe`).
+  File mode (with `spiffe-helper`) needs no extra dependency.
+
+## Anthropic Console setup
+
+Create a Workload Identity Federation rule whose issuer is your SPIRE trust
+domain and whose subject matches the workload's SPIFFE ID. Export the resulting
+identifiers as `ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_ORGANIZATION_ID`, and
+`ANTHROPIC_SERVICE_ACCOUNT_ID`.
+
+## Usage
+
+=== "Auto"
+
+    ```python
+    from promptise.identity import AgentIdentity
+
+    # File mode if token_file is given, else SDK mode.
+    identity = AgentIdentity.from_spiffe()
+    ```
+
+=== "File (spiffe-helper)"
+
+    ```python
+    identity = AgentIdentity.from_spiffe(
+        token_file="/run/spiffe/jwt-svid.token",
+    )
+    ```
+
+=== "SDK (Workload API)"
+
+    ```python
+    identity = AgentIdentity.from_spiffe(
+        mode="sdk",
+        socket_path="unix:///run/spire/agent/api.sock",
+        # or rely on $SPIFFE_ENDPOINT_SOCKET
+    )
+    ```
+
+Wire it into an agent:
+
+```python
+from promptise import build_agent
+
+agent = await build_agent(
+    model="anthropic:claude-sonnet-4-5",
+    servers={},
+    identity=AgentIdentity.from_spiffe(),
+)
+```
+
+## Verify
+
+```python
+identity = AgentIdentity.from_spiffe(token_file="/run/spiffe/jwt-svid.token")
+print(identity.provider_name)         # spiffe-file or spiffe-sdk
+assert identity.get_token().startswith("sk-ant-oat01-")
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `ProviderConfigError: … pip install promptise[identity-spiffe]` | SDK mode selected but `pyspiffe` is not installed. Install the extra, or use file mode with `spiffe-helper`. |
+| `TokenAcquisitionError: fetching a JWT-SVID … failed` | No SPIRE agent is listening on the socket, or the workload has no registration entry. |
+| `TokenAcquisitionError: … serialized token could not be extracted` | The installed `pyspiffe` exposes the token under an unexpected accessor — upgrade or switch to file mode. |
+| File mode: file-not-found | `spiffe-helper` is not running or writes to a different path. |
+| `TokenExchangeError` | The Console rule's issuer/audience does not match the SVID. |

--- a/docs/identity/quickstart.md
+++ b/docs/identity/quickstart.md
@@ -1,0 +1,130 @@
+# Quickstart
+
+This five-minute path gets you a working federated agent with **no cloud
+account**. It uses the [generic OIDC](providers/oidc.md) env-var mode, so you
+can run it on a laptop or in a plain Docker container — the same code then works
+unchanged on AWS, GCP, Azure, or Kubernetes by swapping the factory.
+
+## 1. Register a federation rule
+
+In the [Anthropic Console](https://console.anthropic.com), create a Workload
+Identity Federation rule for your issuer and note three identifiers:
+
+- the federation rule id (`fdrl_…`),
+- your organization id (a UUID),
+- the service account id (`svac_…`).
+
+These are **identifiers, not secrets** — but treat them as configuration, not
+literals in code.
+
+## 2. Set the environment
+
+```bash
+export ANTHROPIC_FEDERATION_RULE_ID=fdrl_your_rule_id
+export ANTHROPIC_ORGANIZATION_ID=your_org_uuid
+export ANTHROPIC_SERVICE_ACCOUNT_ID=svac_your_service_account
+
+# The issuer's OIDC token. In CI this is set for you (e.g. $CI_JOB_JWT_V2 on
+# GitLab, the OIDC token on a GitHub Actions runner). Here we read one you
+# already have on disk:
+export MY_OIDC_TOKEN="$(cat ./oidc_token.jwt)"
+
+# Make sure no static key is present — it would shadow the federated identity
+# and build_agent() will refuse to start.
+unset ANTHROPIC_API_KEY
+```
+
+## 3. Build the agent
+
+```python
+import asyncio
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+
+async def main() -> None:
+    identity = AgentIdentity.from_oidc(
+        issuer="https://gitlab.com",
+        token_env_var="MY_OIDC_TOKEN",
+        # federation_rule_id / organization_id / service_account_id are read
+        # from the ANTHROPIC_* environment variables set above.
+    )
+
+    agent = await build_agent(
+        model="anthropic:claude-sonnet-4-5",
+        servers={},
+        identity=identity,
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "Say hello in one sentence."}]}
+    )
+    print(result["messages"][-1].content)
+    await agent.shutdown()
+
+
+asyncio.run(main())
+```
+
+That is the whole integration. `build_agent` authenticates the agent's own
+Anthropic calls with the federated token — no `ANTHROPIC_API_KEY` anywhere.
+
+## 4. Verify the token exchange directly
+
+You can mint a token without building an agent, which is handy for debugging:
+
+```python
+from promptise.identity import AgentIdentity
+
+identity = AgentIdentity.from_oidc(
+    issuer="https://gitlab.com",
+    token_env_var="MY_OIDC_TOKEN",
+)
+
+token = identity.get_token()          # exchanges + caches
+assert token.startswith("sk-ant-oat01-")
+print(identity.get_auth_header())     # {"Authorization": "Bearer sk-ant-oat01-…"}
+```
+
+`get_token()` is cached and thread-safe: repeated calls return the same token
+until it nears expiry, then refresh transparently.
+
+## 5. Move to a real platform
+
+When you deploy, delete the `MY_OIDC_TOKEN` plumbing and swap one line:
+
+=== "AWS"
+
+    ```python
+    identity = AgentIdentity.from_aws()
+    ```
+
+=== "GCP"
+
+    ```python
+    identity = AgentIdentity.from_gcp()
+    ```
+
+=== "Azure"
+
+    ```python
+    identity = AgentIdentity.from_entra()
+    ```
+
+=== "SPIFFE"
+
+    ```python
+    identity = AgentIdentity.from_spiffe()
+    ```
+
+=== "Auto-detect"
+
+    ```python
+    identity = AgentIdentity.auto()
+    ```
+
+Each provider has its own setup page with prerequisites, Console configuration,
+and troubleshooting — see [Microsoft Entra](providers/entra.md),
+[AWS](providers/aws.md), [Google Cloud](providers/gcp.md),
+[SPIFFE](providers/spiffe.md), and [Generic OIDC](providers/oidc.md).

--- a/docs/identity/security.md
+++ b/docs/identity/security.md
@@ -1,0 +1,96 @@
+# Security
+
+Agent Identity exists to remove static credentials from agent code. This page
+states what it guarantees, what it deliberately does not, and how it handles
+secrets.
+
+## Secret-handling guarantees
+
+- **Tokens live in memory only.** A `MintedToken` is cached on the provider
+  instance and never written to disk, never serialized, and never persisted.
+- **No credential is ever logged.** Not at `DEBUG`, not at any level. The
+  upstream JWT and the minted `sk-ant-oat01-…` access token are never emitted
+  to logs. The test suite asserts that no log record contains either token
+  shape.
+- **`repr()` is identifier-only.** `repr(AgentIdentity(...))` shows the provider
+  name, the service account id, and the optional workspace id — never a token,
+  even after one has been minted and cached.
+- **Bearer, not API key.** Minted tokens are OAuth bearer tokens; they are sent
+  in the `Authorization` header, never as `x-api-key`.
+- **No static key shadowing.** `build_agent(identity=…)` refuses to start if
+  `ANTHROPIC_API_KEY` is also set, so a stray environment key cannot silently
+  override a federated identity.
+
+## Threat model
+
+### What the framework protects against
+
+- **Long-lived key leakage.** There is no `ANTHROPIC_API_KEY` to commit, print,
+  or copy into a ticket. Tokens are short-lived and rotated automatically.
+- **Credential sprawl across tools.** MCP tools call
+  `agent.identity.get_auth_header()` for a fresh bearer token instead of each
+  carrying its own secret.
+- **Clock-skew refresh bugs.** Expiry is tracked with `time.monotonic()`, so a
+  wall-clock jump cannot cause a stale token to be treated as valid (or a valid
+  one as expired).
+- **Thundering-herd refresh.** A `threading.Lock` collapses concurrent
+  `get_token()` callers into a single exchange.
+
+### What it does *not* protect against
+
+- **A compromised host.** If an attacker can read process memory or the
+  platform's projected token file, they can impersonate the workload. That is
+  the platform's trust boundary, not the framework's.
+- **Cross-process token theft.** The cache is process-local **by design**.
+  Sharing minted tokens across processes is a security problem the framework
+  does not attempt to solve at this layer — each process performs its own
+  exchange.
+- **Misconfigured federation rules.** If the Anthropic Console rule trusts the
+  wrong issuer or audience, the framework will faithfully exchange whatever the
+  platform issues. Federation-rule correctness is an operator responsibility.
+- **Optional-SDK supply chain.** `boto3` (AWS STS mode) and `pyspiffe` (SPIFFE
+  SDK mode) are optional dependencies you opt into; their supply-chain posture
+  is yours to manage.
+
+## Optional dependencies and isolation
+
+The cloud SDKs are never imported at module load. `boto3` and `pyspiffe` are
+imported *inside* the acquisition method, so a workload that uses file-based
+modes (EKS-projected, `spiffe-helper`, AKS Workload Identity) needs neither
+installed. When an SDK is missing, the provider raises
+[`ProviderConfigError`](#errors) naming the exact install command
+(`pip install promptise[identity-aws]` or `promptise[identity-spiffe]`).
+
+## Errors
+
+All identity errors derive from `IdentityError`, so a single `except
+IdentityError` catches the whole subsystem.
+
+| Exception | Raised when |
+| --- | --- |
+| `IdentityError` | Base class for every error below. |
+| `TokenAcquisitionError` | The upstream platform could not supply a JWT (metadata unreachable, STS denied, token file missing, Workload API down). |
+| `TokenExchangeError` | Anthropic rejected the RFC 7523 exchange (bad rule, audience, or expired JWT). |
+| `ProviderConfigError` | Misconfiguration or a missing optional SDK — names the fix in the message. |
+| `CredentialPrecedenceError` | `build_agent(identity=…)` was called while `ANTHROPIC_API_KEY` is set. |
+| `PlatformDetectionError` | `AgentIdentity.auto()` found no platform marker. |
+
+Every message names the provider, the operation that failed, and the most
+likely fix. See the [API reference](../api/identity.md) for the exact classes.
+
+## Logging
+
+The subsystem uses one logger, `promptise.identity`, with `NullHandler`
+installed by default (library best practice). Per-provider sub-loggers
+(`promptise.identity.aws`, …) inherit from it. Configure the parent to control
+the whole subsystem:
+
+```python
+import logging
+
+logging.getLogger("promptise.identity").setLevel(logging.INFO)
+```
+
+Levels: `INFO` for successful mints (provider, scope, `expires_in` — never the
+token), `WARNING` for advisory-refresh failures (cached token still valid),
+`ERROR` for mandatory-refresh and runtime configuration failures.

--- a/examples/identity/aks_workload/app.py
+++ b/examples/identity/aks_workload/app.py
@@ -1,0 +1,52 @@
+"""AKS workload — federated Anthropic auth with AgentIdentity.from_entra().
+
+Demonstrates:
+- AgentIdentity.from_entra() reading the projected token AKS Workload Identity
+  writes to $AZURE_FEDERATED_TOKEN_FILE (mode="auto" -> "projected" on AKS)
+- build_agent(identity=...) with NO ANTHROPIC_API_KEY
+- a single real agent invocation
+
+Run (inside an AKS pod with Workload Identity enabled):
+    python app.py
+
+Required environment (federation identifiers from the Anthropic Console):
+    ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+    ANTHROPIC_SERVICE_ACCOUNT_ID
+    (AZURE_FEDERATED_TOKEN_FILE and AZURE_CLIENT_ID are injected by AKS.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+
+async def main() -> None:
+    identity = AgentIdentity.from_entra()
+    print(
+        f"[identity] provider={identity.provider_name} "
+        f"service_account={identity.service_account_id}"
+    )
+    agent = await build_agent(
+        model="anthropic:claude-sonnet-4-5",
+        servers={},
+        identity=identity,
+    )
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "In one sentence, what is workload identity federation?",
+                }
+            ]
+        }
+    )
+    print("[agent]", result["messages"][-1].content)
+    await agent.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/identity/aks_workload/deployment.yaml
+++ b/examples/identity/aks_workload/deployment.yaml
@@ -1,0 +1,52 @@
+# AKS Deployment — federated-identity agent using Azure Workload Identity.
+#
+# Prerequisites (manual):
+#   1. Enable the OIDC issuer and Workload Identity add-on on the AKS cluster.
+#   2. Create a managed identity and a federated credential that trusts this
+#      Kubernetes service account:
+#        az identity federated-credential create \
+#          --name promptise-agent --identity-name AGENT_MI \
+#          --resource-group RG --issuer "$AKS_OIDC_ISSUER" \
+#          --subject system:serviceaccount:NAMESPACE:promptise-agent \
+#          --audience api://AzureADTokenExchange
+#   3. Register a Workload Identity Federation rule in the Anthropic Console
+#      trusting your Entra tenant, then fill in the ANTHROPIC_* identifiers
+#      below (identifiers, not secrets).
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promptise-agent
+  annotations:
+    azure.workload.identity/client-id: AGENT_MANAGED_IDENTITY_CLIENT_ID
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promptise-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promptise-agent
+  template:
+    metadata:
+      labels:
+        app: promptise-agent
+        azure.workload.identity/use: "true"   # injects the projected token
+    spec:
+      serviceAccountName: promptise-agent
+      containers:
+        - name: agent
+          image: YOUR_REGISTRY/promptise-agent:latest
+          command: ["python", "app.py"]
+          env:
+            # No ANTHROPIC_API_KEY — the managed identity is the identity.
+            # AZURE_FEDERATED_TOKEN_FILE and AZURE_CLIENT_ID are injected
+            # automatically by the Workload Identity webhook.
+            - name: ANTHROPIC_FEDERATION_RULE_ID
+              value: "fdrl_your_rule_id"
+            - name: ANTHROPIC_ORGANIZATION_ID
+              value: "your_org_uuid"
+            - name: ANTHROPIC_SERVICE_ACCOUNT_ID
+              value: "svac_your_service_account"

--- a/examples/identity/aws_lambda/handler.py
+++ b/examples/identity/aws_lambda/handler.py
@@ -1,0 +1,50 @@
+"""AWS Lambda — federated Anthropic auth with AgentIdentity.from_aws().
+
+Demonstrates:
+- AgentIdentity.from_aws() using the function's execution-role identity via
+  STS GetWebIdentityToken (mode="auto" -> "sts" on Lambda)
+- build_agent(identity=...) with NO ANTHROPIC_API_KEY
+- driving the agent from a synchronous Lambda entrypoint via asyncio.run
+
+Deploy:
+    sam build && sam deploy --guided
+
+Required environment (set in template.yaml; identifiers from the Console):
+    ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+    ANTHROPIC_SERVICE_ACCOUNT_ID
+
+Packaging note: STS mode needs boto3 (already present in the Lambda runtime)
+and the AWS extra locally — install with: pip install promptise[identity-aws]
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+
+async def _run(prompt: str) -> str:
+    # AWS_REGION is set automatically in the Lambda environment, so
+    # from_aws() needs no arguments.
+    identity = AgentIdentity.from_aws()
+    agent = await build_agent(
+        model="anthropic:claude-sonnet-4-5",
+        servers={},
+        identity=identity,
+    )
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": prompt}]}
+    )
+    answer = result["messages"][-1].content
+    await agent.shutdown()
+    return str(answer)
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Lambda entrypoint."""
+    prompt = event.get("prompt", "Say hello in one sentence.")
+    answer = asyncio.run(_run(prompt))
+    return {"statusCode": 200, "body": answer}

--- a/examples/identity/aws_lambda/template.yaml
+++ b/examples/identity/aws_lambda/template.yaml
@@ -1,0 +1,48 @@
+# AWS SAM template — federated-identity agent on Lambda.
+#
+# Deploy: sam build && sam deploy --guided
+#
+# The function authenticates to Anthropic with its IAM execution-role identity
+# (STS GetWebIdentityToken) — there is NO ANTHROPIC_API_KEY. Register a Workload
+# Identity Federation rule in the Anthropic Console trusting this account/role,
+# then set the three identifiers below (they are identifiers, not secrets).
+
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Promptise federated-identity agent (Lambda)
+
+Parameters:
+  FederationRuleId:
+    Type: String
+    Description: The fdrl_* identifier from the Anthropic Console.
+  OrganizationId:
+    Type: String
+    Description: The Anthropic organization UUID.
+  ServiceAccountId:
+    Type: String
+    Description: The svac_* identifier.
+
+Resources:
+  AgentFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: promptise-federated-agent
+      Runtime: python3.12
+      Handler: handler.handler
+      CodeUri: .
+      Timeout: 60
+      MemorySize: 512
+      Environment:
+        Variables:
+          ANTHROPIC_FEDERATION_RULE_ID: !Ref FederationRuleId
+          ANTHROPIC_ORGANIZATION_ID: !Ref OrganizationId
+          ANTHROPIC_SERVICE_ACCOUNT_ID: !Ref ServiceAccountId
+      # No inline credentials — the execution role IS the identity. Attach any
+      # additional policies the agent's tools need here.
+      Policies:
+        - AWSLambdaBasicExecutionRole
+
+Outputs:
+  AgentFunctionArn:
+    Description: The deployed function ARN.
+    Value: !GetAtt AgentFunction.Arn

--- a/examples/identity/github_actions/script.py
+++ b/examples/identity/github_actions/script.py
@@ -1,0 +1,77 @@
+"""GitHub Actions — federated Anthropic auth from an OIDC runner token.
+
+Demonstrates:
+- AgentIdentity.from_oidc() reading the GitHub Actions OIDC token from an
+  environment variable the workflow exported
+- build_agent(identity=...) with NO ANTHROPIC_API_KEY in the environment
+- a single real agent invocation against an Anthropic model
+
+This is the example exercised end-to-end by
+``.github/workflows/identity-integration.yml`` on every pull request.
+
+Run (inside a GitHub Actions job that set GITHUB_OIDC_TOKEN):
+    python examples/identity/github_actions/script.py
+
+Required environment (federation identifiers from the Anthropic Console):
+    ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+    ANTHROPIC_SERVICE_ACCOUNT_ID
+    GITHUB_OIDC_TOKEN  (the issuer JWT; the workflow fetches and exports it)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity, IdentityError
+
+
+async def main() -> int:
+    if not os.environ.get("GITHUB_OIDC_TOKEN"):
+        print("GITHUB_OIDC_TOKEN is not set — run this inside the workflow.")
+        return 2
+
+    identity = AgentIdentity.from_oidc(
+        issuer="https://token.actions.githubusercontent.com",
+        token_env_var="GITHUB_OIDC_TOKEN",
+        # federation_rule_id / organization_id / service_account_id are read
+        # from the ANTHROPIC_* environment variables.
+    )
+    print(
+        f"[identity] provider={identity.provider_name} "
+        f"service_account={identity.service_account_id}"
+    )
+
+    try:
+        # Prove the exchange works before spending tokens on an LLM call.
+        token = identity.get_token()
+        assert token.startswith("sk-ant-oat01-")
+        print("[identity] federated token minted successfully")
+
+        agent = await build_agent(
+            model="anthropic:claude-sonnet-4-5",
+            servers={},
+            identity=identity,
+        )
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "In one sentence, what is workload identity federation?",
+                    }
+                ]
+            }
+        )
+        print("[agent]", result["messages"][-1].content)
+        await agent.shutdown()
+    except IdentityError as exc:
+        print(f"[identity] federation failed: {type(exc).__name__}: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/identity/github_actions/workflow.yml
+++ b/examples/identity/github_actions/workflow.yml
@@ -1,0 +1,53 @@
+# Sample GitHub Actions workflow — copy into .github/workflows/ in YOUR repo.
+#
+# It mints a GitHub OIDC token, exports it, and runs an agent authenticated by
+# federated identity — no ANTHROPIC_API_KEY anywhere.
+#
+# One-time setup in the Anthropic Console (manual):
+#   1. Create a Workload Identity Federation rule whose issuer is
+#        https://token.actions.githubusercontent.com
+#      audience  https://api.anthropic.com
+#      and whose subject matches your repo (e.g. repo:OWNER/REPO:ref:refs/heads/main).
+#   2. Set these as repository variables (Settings → Secrets and variables →
+#      Actions → Variables):
+#        ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+#        ANTHROPIC_SERVICE_ACCOUNT_ID
+#
+# Note: these are identifiers, not secrets — repository *variables* are fine.
+
+name: Agent (federated identity)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # REQUIRED — lets the job request an OIDC token
+  contents: read
+
+jobs:
+  run-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install promptise
+        run: pip install promptise
+
+      - name: Mint the GitHub OIDC token
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('https://api.anthropic.com')
+            core.exportVariable('GITHUB_OIDC_TOKEN', token)
+
+      - name: Run the agent
+        env:
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          # GITHUB_OIDC_TOKEN was exported by the previous step.
+        run: python script.py

--- a/examples/identity/gke_pod/app.py
+++ b/examples/identity/gke_pod/app.py
@@ -1,0 +1,51 @@
+"""GKE pod — federated Anthropic auth with AgentIdentity.from_gcp().
+
+Demonstrates:
+- AgentIdentity.from_gcp() reading an identity token from the GCP compute
+  metadata server (works on GKE with Workload Identity, GCE, Cloud Run, …)
+- build_agent(identity=...) with NO ANTHROPIC_API_KEY
+- a single real agent invocation
+
+Run (inside a GKE pod bound to a GCP service account):
+    python app.py
+
+Required environment (federation identifiers from the Anthropic Console):
+    ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+    ANTHROPIC_SERVICE_ACCOUNT_ID
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+
+async def main() -> None:
+    identity = AgentIdentity.from_gcp()
+    print(
+        f"[identity] provider={identity.provider_name} "
+        f"service_account={identity.service_account_id}"
+    )
+    agent = await build_agent(
+        model="anthropic:claude-sonnet-4-5",
+        servers={},
+        identity=identity,
+    )
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "In one sentence, what is workload identity federation?",
+                }
+            ]
+        }
+    )
+    print("[agent]", result["messages"][-1].content)
+    await agent.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/identity/gke_pod/deployment.yaml
+++ b/examples/identity/gke_pod/deployment.yaml
@@ -1,0 +1,48 @@
+# GKE Deployment — federated-identity agent using Workload Identity.
+#
+# Prerequisites (manual):
+#   1. Enable Workload Identity on the cluster.
+#   2. Create a GCP service account (GSA) and bind it to this Kubernetes
+#      service account (KSA):
+#        gcloud iam service-accounts add-iam-policy-binding \
+#          AGENT_GSA@PROJECT_ID.iam.gserviceaccount.com \
+#          --role roles/iam.workloadIdentityUser \
+#          --member "serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/promptise-agent]"
+#   3. Register a Workload Identity Federation rule in the Anthropic Console
+#      trusting Google (https://accounts.google.com) for this GSA, then fill in
+#      the ANTHROPIC_* identifiers below (identifiers, not secrets).
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promptise-agent
+  annotations:
+    iam.gke.io/gcp-service-account: AGENT_GSA@PROJECT_ID.iam.gserviceaccount.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promptise-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promptise-agent
+  template:
+    metadata:
+      labels:
+        app: promptise-agent
+    spec:
+      serviceAccountName: promptise-agent   # binds the pod to the GSA
+      containers:
+        - name: agent
+          image: YOUR_REGISTRY/promptise-agent:latest
+          command: ["python", "app.py"]
+          env:
+            # No ANTHROPIC_API_KEY — the GSA is the identity.
+            - name: ANTHROPIC_FEDERATION_RULE_ID
+              value: "fdrl_your_rule_id"
+            - name: ANTHROPIC_ORGANIZATION_ID
+              value: "your_org_uuid"
+            - name: ANTHROPIC_SERVICE_ACCOUNT_ID
+              value: "svac_your_service_account"

--- a/examples/identity/spire/app.py
+++ b/examples/identity/spire/app.py
@@ -1,0 +1,57 @@
+"""SPIRE workload — federated Anthropic auth with AgentIdentity.from_spiffe().
+
+Demonstrates:
+- AgentIdentity.from_spiffe() fetching a JWT-SVID from the SPIRE agent's
+  Workload API socket (SDK mode); $SPIFFE_ENDPOINT_SOCKET selects the socket
+- build_agent(identity=...) with NO ANTHROPIC_API_KEY
+- a single real agent invocation
+
+Run (inside a workload registered with SPIRE):
+    python app.py
+
+SDK mode needs pyspiffe:  pip install promptise[identity-spiffe]
+(For the file-based alternative — spiffe-helper writing a JWT-SVID to disk —
+use AgentIdentity.from_spiffe(token_file="/run/spiffe/jwt-svid.token"), which
+needs no pyspiffe.)
+
+Required environment (federation identifiers from the Anthropic Console):
+    ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+    ANTHROPIC_SERVICE_ACCOUNT_ID
+    SPIFFE_ENDPOINT_SOCKET  (e.g. unix:///run/spire/agent/api.sock)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from promptise import build_agent
+from promptise.identity import AgentIdentity
+
+
+async def main() -> None:
+    identity = AgentIdentity.from_spiffe()  # SDK mode via $SPIFFE_ENDPOINT_SOCKET
+    print(
+        f"[identity] provider={identity.provider_name} "
+        f"service_account={identity.service_account_id}"
+    )
+    agent = await build_agent(
+        model="anthropic:claude-sonnet-4-5",
+        servers={},
+        identity=identity,
+    )
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "In one sentence, what is workload identity federation?",
+                }
+            ]
+        }
+    )
+    print("[agent]", result["messages"][-1].content)
+    await agent.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/identity/spire/spire-config.yaml
+++ b/examples/identity/spire/spire-config.yaml
@@ -1,0 +1,58 @@
+# SPIRE configuration — federated-identity agent.
+#
+# This shows the two pieces a SPIRE workload needs: a registration entry that
+# grants the workload a SPIFFE ID, and the pod wiring that mounts the Workload
+# API socket so AgentIdentity.from_spiffe() can fetch a JWT-SVID.
+#
+# Prerequisites (manual):
+#   1. A running SPIRE server + agent (e.g. the spiffe/spire Helm chart).
+#   2. Register a Workload Identity Federation rule in the Anthropic Console
+#      trusting your SPIRE trust domain (spiffe://example.org), then fill in
+#      the ANTHROPIC_* identifiers below (identifiers, not secrets).
+#
+# Create the registration entry (run against the SPIRE server):
+#   spire-server entry create \
+#     -spiffeID spiffe://example.org/promptise-agent \
+#     -parentID spiffe://example.org/spire/agent/k8s_psat/CLUSTER/NODE \
+#     -selector k8s:ns:default \
+#     -selector k8s:sa:promptise-agent \
+#     -jwtSVIDTTL 3600
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promptise-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promptise-agent
+  template:
+    metadata:
+      labels:
+        app: promptise-agent
+    spec:
+      serviceAccountName: promptise-agent
+      containers:
+        - name: agent
+          image: YOUR_REGISTRY/promptise-agent:latest
+          command: ["python", "app.py"]
+          env:
+            # No ANTHROPIC_API_KEY — the SPIFFE identity is the identity.
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: "unix:///run/spire/agent/api.sock"
+            - name: ANTHROPIC_FEDERATION_RULE_ID
+              value: "fdrl_your_rule_id"
+            - name: ANTHROPIC_ORGANIZATION_ID
+              value: "your_org_uuid"
+            - name: ANTHROPIC_SERVICE_ACCOUNT_ID
+              value: "svac_your_service_account"
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/agent
+              readOnly: true
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/agent
+            type: Directory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,19 @@ nav:
       - Dashboard: runtime/dashboard.md
       - CLI Commands: runtime/cli.md
 
+  - Agent Identity:
+      - Overview: identity/overview.md
+      - Quickstart: identity/quickstart.md
+      - Architecture: identity/architecture.md
+      - Providers:
+          - Microsoft Entra ID: identity/providers/entra.md
+          - AWS IAM: identity/providers/aws.md
+          - Google Cloud: identity/providers/gcp.md
+          - SPIFFE / SPIRE: identity/providers/spiffe.md
+          - Generic OIDC: identity/providers/oidc.md
+      - Security: identity/security.md
+      - Migration: identity/migration.md
+
   - Prompting & Context:
       - prompting/index.md
       - Building Prompts:
@@ -268,6 +281,8 @@ nav:
           - RAG: api/rag.md
           - Sandbox: api/sandbox.md
           - Observability: api/observability.md
+      - Identity:
+          - Agent Identity: api/identity.md
       - MCP:
           - MCP Server: api/mcp-server.md
           - MCP Client: api/mcp-client.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,25 @@ all = [
 # without it.
 identity-aws = ["boto3>=1.34"]
 
+# pip install promptise[identity-spiffe]
+# SPIFFE / SPIRE federation via the Workload API. Only needed for the
+# SpiffeSdkProvider; the spiffe-helper file mode and every other provider
+# work without it.
+identity-spiffe = ["pyspiffe>=1.0"]
+
+# pip install promptise[identity-all]
+# Every optional cloud SDK used by the identity providers. Convenience
+# aggregate for images that must support all federation backends.
+identity-all = [
+  "promptise[identity-aws]",
+  "promptise[identity-spiffe]",
+]
+
 # pip install promptise[dev]
 # Contributors only. Everything in [all] plus test runners, lint, docs tooling.
 dev = [
   "promptise[all]",
-  "promptise[identity-aws]",
+  "promptise[identity-all]",
   # Tests
   "pytest>=8.4",
   "pytest-asyncio>=1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,17 @@ all = [
   "prometheus_client>=0.20.0",
 ]
 
+# pip install promptise[identity-aws]
+# AWS IAM federation via STS GetWebIdentityToken. Only needed for the
+# AwsStsProvider; the EKS-projected mode and every other provider work
+# without it.
+identity-aws = ["boto3>=1.34"]
+
 # pip install promptise[dev]
 # Contributors only. Everything in [all] plus test runners, lint, docs tooling.
 dev = [
   "promptise[all]",
+  "promptise[identity-aws]",
   # Tests
   "pytest>=8.4",
   "pytest-asyncio>=1.1",

--- a/src/promptise/agent.py
+++ b/src/promptise/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import logging
+import os
 import time
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
@@ -20,6 +21,7 @@ from promptise.engine import PromptGraph, PromptGraphEngine
 
 from .config import HTTPServerSpec, ServerSpec
 from .cross_agent import CrossAgent, make_cross_agent_tools
+from .identity import AgentIdentity, CredentialPrecedenceError
 from .prompt import DEFAULT_SYSTEM_PROMPT
 
 
@@ -224,6 +226,11 @@ class PromptiseAgent:
         self._raw_instructions: str = ""
         self._sandbox_session: Any | None = None
         self._sandbox_manager: Any | None = None
+
+        # Federated workload identity (optional; set by build_agent()).
+        # Exposed publicly so MCP tools and downstream calls can mint
+        # authenticated headers via ``agent.identity.get_auth_header()``.
+        self.identity: AgentIdentity | None = None
 
     # -----------------------------------------------------------------
     # Core invocation methods
@@ -1660,9 +1667,32 @@ def _extract_response_text(output: Any) -> str:
     return str(output)
 
 
-def _normalize_model(model: ModelLike) -> Runnable[Any, Any]:
-    """Normalize the supplied model into a Runnable."""
+def _normalize_model(
+    model: ModelLike, identity: AgentIdentity | None = None
+) -> Runnable[Any, Any]:
+    """Normalize the supplied model into a Runnable.
+
+    When an :class:`~promptise.identity.AgentIdentity` is provided and
+    *model* is a provider id string, the agent's own Anthropic calls are
+    authenticated with the federated token instead of a static API key.
+    Anthropic OAuth access tokens are *bearer* tokens, so the token is
+    placed in the ``Authorization`` header (``api_key=""`` keeps the SDK
+    from also sending an ``x-api-key`` header). A pre-built chat model
+    instance is returned untouched — supply a model string to have the
+    identity injected.
+    """
     if isinstance(model, str):
+        if identity is not None:
+            return cast(
+                Runnable[Any, Any],
+                init_chat_model(
+                    model,
+                    api_key="",
+                    default_headers={
+                        "Authorization": f"Bearer {identity.get_token()}"
+                    },
+                ),
+            )
         # This supports many providers via lc init strings, not just OpenAI.
         return cast(Runnable[Any, Any], init_chat_model(model))
     # Already BaseChatModel or Runnable
@@ -1674,6 +1704,7 @@ async def build_agent(
     servers: Mapping[str, ServerSpec],
     model: ModelLike,
     instructions: str | Any | None = None,
+    identity: AgentIdentity | None = None,
     trace_tools: bool = False,
     cross_agents: Mapping[str, CrossAgent] | None = None,
     sandbox: bool | dict[str, Any] | None = None,
@@ -1713,6 +1744,19 @@ async def build_agent(
             string accepted by ``init_chat_model``, or a Runnable.
         instructions: Optional system prompt.  Defaults to the built-in
             ``DEFAULT_SYSTEM_PROMPT``.
+        identity: Optional :class:`~promptise.identity.AgentIdentity` for
+            zero-static-credential, federated authentication. When
+            provided and *model* is a provider id string, the agent's own
+            Anthropic calls are authenticated with the federated token
+            (no ``ANTHROPIC_API_KEY`` needed) and the identity is exposed
+            as :attr:`PromptiseAgent.identity` so MCP tools can make
+            authenticated downstream calls via
+            ``agent.identity.get_auth_header()``. Raises
+            :class:`~promptise.identity.CredentialPrecedenceError` if
+            ``ANTHROPIC_API_KEY`` is also set, rather than let the static
+            key silently shadow the federated identity. The token is
+            resolved when the model is built; long-lived agents that
+            outlive the token should be rebuilt to pick up a fresh one.
         trace_tools: Print each tool invocation and result to stdout.
         cross_agents: Optional mapping of peer name → CrossAgent.  Each
             peer is exposed as an ``ask_agent_<name>`` tool.
@@ -1752,6 +1796,14 @@ async def build_agent(
     """
     if model is None:  # Defensive check; CLI/code must always pass a model now.
         raise ValueError("A model is required. Provide a model instance or a provider id string.")
+
+    # Refuse to let a static API key silently shadow a federated identity.
+    if identity is not None and os.environ.get("ANTHROPIC_API_KEY"):
+        raise CredentialPrecedenceError(
+            "Both an AgentIdentity and ANTHROPIC_API_KEY are configured. "
+            "The static API key would silently shadow the federated identity. "
+            "Either unset ANTHROPIC_API_KEY or remove the identity= argument."
+        )
 
     # Simple printing callbacks for tracing (kept dependency-free).
     # When an observer is provided the callbacks also record tool events
@@ -1959,7 +2011,7 @@ async def build_agent(
     if not tools:
         print("[promptise] No tools discovered from MCP servers; agent will run without tools.")
 
-    chat: Runnable[Any, Any] = _normalize_model(model)
+    chat: Runnable[Any, Any] = _normalize_model(model, identity)
 
     # Handle Prompt/PromptSuite as instructions
     _prompt_config = None
@@ -2165,6 +2217,9 @@ async def build_agent(
         approval=approval,
         event_notifier=events,
     )
+
+    # Attach the federated identity (if any) for downstream/tool auth.
+    agent.identity = identity
 
     # Set invocation timeout
     if max_invocation_time > 0:

--- a/src/promptise/identity/DEFERRED.md
+++ b/src/promptise/identity/DEFERRED.md
@@ -1,0 +1,56 @@
+# Agent Identity — deferred items
+
+Everything shipped in this subsystem is fully implemented; nothing here is a
+stub. This file records work intentionally left for a follow-up PR, with the
+reason it was deferred and the contract a future change should honor.
+
+## 1. Audit-log enrichment in Security Guardrails
+
+**What:** Stamp every Guardrails audit-log entry with two fields when an
+`AgentIdentity` is attached to an agent:
+
+- `identity.provider` — `agent.identity.provider_name` (e.g. `aws-sts`)
+- `identity.service_account_id` — `agent.identity.service_account_id`
+
+**Why deferred:** the audit-log writer lives in the Guardrails subsystem
+(`src/promptise/guardrails.py` / the `AuditMiddleware`), outside this
+subsystem's allowed change surface. Editing it cleanly is a cross-subsystem
+change that should be owned/reviewed by Guardrails.
+
+**Contract:** the two values are already exposed as public attributes on
+`AgentIdentity` (and reachable via `agent.identity`), so the follow-up is purely
+additive on the writer side. Documented in
+[`docs/identity/architecture.md`](../../../docs/identity/architecture.md)
+under "Audit-log enrichment".
+
+## 2. First-class Anthropic-SDK workload-identity credential
+
+**What:** Authenticate the agent's own Anthropic LLM calls through a dedicated
+Anthropic-SDK credential type instead of the current header injection.
+
+**Why deferred:** the installed `anthropic` SDK (0.96.0) exposes no
+`WorkloadIdentityCredentials` (or equivalent), and `build_agent()` constructs
+models through LangChain `init_chat_model`, not a raw `anthropic.Anthropic`
+client. Phase 8 therefore injects the minted bearer token at the
+model-construction layer via `default_headers={"Authorization": "Bearer …"}`
+(the same header shape the SDK's `auth_token` produces) — which works on the
+SDK versions Promptise targets today.
+
+**Contract:** when a future Anthropic SDK ships a workload-identity credential
+(or `langchain_anthropic.ChatAnthropic` exposes `auth_token`), migrate
+`_normalize_model()` in `src/promptise/agent.py` onto it. The `AgentIdentity`
+public surface (`get_token`, `get_upstream_jwt`, the federation identifiers)
+already provides everything such a credential needs, so the change is internal
+to `build_agent()` and requires no public-API change.
+
+## 3. Per-request token refresh for long-lived attached agents
+
+**What:** Refresh the federated token automatically for an agent whose process
+outlives the token lifetime, without rebuilding the agent.
+
+**Why deferred:** today the token is resolved when the model is built (see
+Phase 8). `AgentIdentity.get_token()` already performs the two-tier refresh, so
+the cache is sound; what is missing is a hook that re-reads it per request at
+the model layer. This is naturally subsumed by item 2 — an SDK credential that
+calls back into the provider gets refresh for free — so it should be addressed
+together with that migration rather than as a separate header-rewriting shim.

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -44,6 +44,7 @@ from ._core.errors import (
 from ._core.file_provider import FileTokenProvider
 from ._core.provider import IdentityProvider
 from ._internal.logging import _configure_default_handler
+from .providers.oidc import OidcCallableProvider, OidcFileProvider
 
 _configure_default_handler()
 
@@ -56,6 +57,8 @@ __all__ = [
     "IdentityError",
     "IdentityProvider",
     "MintedToken",
+    "OidcCallableProvider",
+    "OidcFileProvider",
     "PlatformDetectionError",
     "ProviderConfigError",
     "TokenAcquisitionError",

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -18,11 +18,12 @@ plus its five ``from_*`` factories. Lower-level classes —
 are exported for advanced use, subclassing, and integration with
 other parts of the framework.
 
-This is the partial ``__init__`` shipped in Phase 1 of the build
-plan: it exposes only the core abstractions plus the two concrete
-provider bases. The provider factories (``from_entra``, ``from_aws``,
-``from_gcp``, ``from_spiffe``, ``from_oidc``) and the
-:class:`AgentIdentity` public class land in later phases.
+The public surface is intentionally small: build an
+:class:`AgentIdentity` with one of its ``from_*`` factories (or
+:meth:`AgentIdentity.auto`), then call :meth:`~AgentIdentity.get_token`
+or hand it to ``build_agent(identity=...)``. The lower-level provider
+classes and exception types are exported for advanced use, custom
+subclassing, and integration with the rest of the framework.
 """
 
 from __future__ import annotations
@@ -44,6 +45,7 @@ from ._core.errors import (
 from ._core.file_provider import FileTokenProvider
 from ._core.provider import IdentityProvider
 from ._internal.logging import _configure_default_handler
+from .agent_identity import AgentIdentity
 from .providers.aws import AwsEksProjectedProvider, AwsStsProvider
 from .providers.entra import (
     EntraManagedIdentityProvider,
@@ -58,6 +60,7 @@ _configure_default_handler()
 __all__ = [
     "ADVISORY_REFRESH_BUFFER_SECONDS",
     "MANDATORY_REFRESH_BUFFER_SECONDS",
+    "AgentIdentity",
     "AwsEksProjectedProvider",
     "AwsStsProvider",
     "CallableTokenProvider",

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -44,6 +44,10 @@ from ._core.errors import (
 from ._core.file_provider import FileTokenProvider
 from ._core.provider import IdentityProvider
 from ._internal.logging import _configure_default_handler
+from .providers.entra import (
+    EntraManagedIdentityProvider,
+    EntraProjectedTokenProvider,
+)
 from .providers.oidc import OidcCallableProvider, OidcFileProvider
 
 _configure_default_handler()
@@ -53,6 +57,8 @@ __all__ = [
     "MANDATORY_REFRESH_BUFFER_SECONDS",
     "CallableTokenProvider",
     "CredentialPrecedenceError",
+    "EntraManagedIdentityProvider",
+    "EntraProjectedTokenProvider",
     "FileTokenProvider",
     "IdentityError",
     "IdentityProvider",

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -51,6 +51,7 @@ from .providers.entra import (
 )
 from .providers.gcp import GcpMetadataProvider
 from .providers.oidc import OidcCallableProvider, OidcFileProvider
+from .providers.spiffe import SpiffeFileProvider, SpiffeSdkProvider
 
 _configure_default_handler()
 
@@ -72,6 +73,8 @@ __all__ = [
     "OidcFileProvider",
     "PlatformDetectionError",
     "ProviderConfigError",
+    "SpiffeFileProvider",
+    "SpiffeSdkProvider",
     "TokenAcquisitionError",
     "TokenExchangeError",
 ]

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -49,6 +49,7 @@ from .providers.entra import (
     EntraManagedIdentityProvider,
     EntraProjectedTokenProvider,
 )
+from .providers.gcp import GcpMetadataProvider
 from .providers.oidc import OidcCallableProvider, OidcFileProvider
 
 _configure_default_handler()
@@ -63,6 +64,7 @@ __all__ = [
     "EntraManagedIdentityProvider",
     "EntraProjectedTokenProvider",
     "FileTokenProvider",
+    "GcpMetadataProvider",
     "IdentityError",
     "IdentityProvider",
     "MintedToken",

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -1,0 +1,63 @@
+"""``promptise.identity`` — Agent Identity subsystem.
+
+The foundation layer for agentic identity. Federated authentication
+for AI agents via Workload Identity Federation — zero static
+credentials in agent code.
+
+Day-one supported providers:
+
+* Microsoft Entra ID (IMDS and projected-token modes)
+* AWS IAM (STS and EKS-projected modes)
+* Google Cloud (compute metadata server)
+* SPIFFE / SPIRE (file and Workload API modes)
+* Generic OIDC (file, callable, env-var)
+
+The user-facing surface is the single class :class:`AgentIdentity`
+plus its five ``from_*`` factories. Lower-level classes —
+:class:`IdentityProvider`, :class:`MintedToken`, exception types —
+are exported for advanced use, subclassing, and integration with
+other parts of the framework.
+
+This is the partial ``__init__`` shipped in Phase 1 of the build
+plan: it exposes only the core abstractions plus the two concrete
+provider bases. The provider factories (``from_entra``, ``from_aws``,
+``from_gcp``, ``from_spiffe``, ``from_oidc``) and the
+:class:`AgentIdentity` public class land in later phases.
+"""
+
+from __future__ import annotations
+
+from ._core.cache import (
+    ADVISORY_REFRESH_BUFFER_SECONDS,
+    MANDATORY_REFRESH_BUFFER_SECONDS,
+    MintedToken,
+)
+from ._core.callable_provider import CallableTokenProvider
+from ._core.errors import (
+    CredentialPrecedenceError,
+    IdentityError,
+    PlatformDetectionError,
+    ProviderConfigError,
+    TokenAcquisitionError,
+    TokenExchangeError,
+)
+from ._core.file_provider import FileTokenProvider
+from ._core.provider import IdentityProvider
+from ._internal.logging import _configure_default_handler
+
+_configure_default_handler()
+
+__all__ = [
+    "ADVISORY_REFRESH_BUFFER_SECONDS",
+    "MANDATORY_REFRESH_BUFFER_SECONDS",
+    "CallableTokenProvider",
+    "CredentialPrecedenceError",
+    "FileTokenProvider",
+    "IdentityError",
+    "IdentityProvider",
+    "MintedToken",
+    "PlatformDetectionError",
+    "ProviderConfigError",
+    "TokenAcquisitionError",
+    "TokenExchangeError",
+]

--- a/src/promptise/identity/__init__.py
+++ b/src/promptise/identity/__init__.py
@@ -44,6 +44,7 @@ from ._core.errors import (
 from ._core.file_provider import FileTokenProvider
 from ._core.provider import IdentityProvider
 from ._internal.logging import _configure_default_handler
+from .providers.aws import AwsEksProjectedProvider, AwsStsProvider
 from .providers.entra import (
     EntraManagedIdentityProvider,
     EntraProjectedTokenProvider,
@@ -55,6 +56,8 @@ _configure_default_handler()
 __all__ = [
     "ADVISORY_REFRESH_BUFFER_SECONDS",
     "MANDATORY_REFRESH_BUFFER_SECONDS",
+    "AwsEksProjectedProvider",
+    "AwsStsProvider",
     "CallableTokenProvider",
     "CredentialPrecedenceError",
     "EntraManagedIdentityProvider",

--- a/src/promptise/identity/_core/__init__.py
+++ b/src/promptise/identity/_core/__init__.py
@@ -1,0 +1,10 @@
+"""Internal core of the Agent Identity subsystem.
+
+This package holds the abstractions that every provider builds on:
+the cache primitive, the exchange engine, the abstract base class,
+and the two concrete bases (file-backed and callable-backed). Code
+outside ``promptise.identity`` should import from the top-level
+``promptise.identity`` namespace rather than reaching into ``_core``.
+"""
+
+from __future__ import annotations

--- a/src/promptise/identity/_core/cache.py
+++ b/src/promptise/identity/_core/cache.py
@@ -1,0 +1,84 @@
+"""Minted-token cache primitive.
+
+This module owns two pieces of state:
+
+* :class:`MintedToken` — the immutable record of one successful
+  exchange. Every provider holds at most one instance in memory.
+* The two refresh-window constants — advisory at expiry − 120 s,
+  mandatory at expiry − 30 s. They are module-level so tests can
+  monkey-patch them without rewriting the dataclass and so other
+  modules can reuse the exact values rather than redefining them.
+
+The token's expiry is anchored to :func:`time.monotonic`, not
+:func:`time.time`. Wall-clock skew — NTP corrections, container
+suspensions, virtualised time — must not affect a token's safety
+window. This is an architectural rule from the build plan, not a
+preference (section 4.5).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+#: Number of seconds before expiry at which the framework attempts an
+#: **advisory** refresh. If the refresh fails, the cached token
+#: continues to be used and a warning is logged.
+ADVISORY_REFRESH_BUFFER_SECONDS: int = 120
+
+#: Number of seconds before expiry at which the framework performs a
+#: **mandatory** refresh. If this refresh fails, an exception is raised
+#: — the cached token is too close to expiry to be safe.
+MANDATORY_REFRESH_BUFFER_SECONDS: int = 30
+
+
+@dataclass(frozen=True, slots=True)
+class MintedToken:
+    """An access token minted by the Anthropic JWT-bearer endpoint.
+
+    Immutable. Every successful call to the exchange endpoint produces
+    a new :class:`MintedToken`; refresh logic replaces the cached
+    instance rather than mutating it.
+
+    Args:
+        access_token: The bearer token returned by Anthropic. Always
+            starts with ``sk-ant-oat01-``; the exchange engine
+            validates this and refuses to construct a :class:`MintedToken`
+            with any other prefix.
+        token_type: OAuth token type, normally ``"Bearer"``. Preserved
+            verbatim from the exchange response.
+        expires_at_monotonic: The value of :func:`time.monotonic` at
+            which this token expires. Computed at mint time as
+            ``mint_monotonic + expires_in_seconds``.
+        expires_in_seconds: The original ``expires_in`` value from the
+            exchange response, retained for diagnostics and metrics.
+    """
+
+    access_token: str
+    token_type: str
+    expires_at_monotonic: float
+    expires_in_seconds: int
+
+    def time_until_expiry(self) -> float:
+        """Seconds of remaining lifetime, using the monotonic clock."""
+        return self.expires_at_monotonic - time.monotonic()
+
+    def needs_advisory_refresh(self) -> bool:
+        """``True`` when the token is inside the advisory window.
+
+        Returns ``True`` once the remaining lifetime drops to or below
+        :data:`ADVISORY_REFRESH_BUFFER_SECONDS`. Callers attempt a
+        refresh; if it fails they continue using the cached token and
+        log a warning.
+        """
+        return self.time_until_expiry() <= ADVISORY_REFRESH_BUFFER_SECONDS
+
+    def needs_mandatory_refresh(self) -> bool:
+        """``True`` when the token is inside the mandatory window.
+
+        Returns ``True`` once the remaining lifetime drops to or below
+        :data:`MANDATORY_REFRESH_BUFFER_SECONDS`. Callers refresh; if
+        the refresh fails they raise — the cached token is too close
+        to expiry to be safe.
+        """
+        return self.time_until_expiry() <= MANDATORY_REFRESH_BUFFER_SECONDS

--- a/src/promptise/identity/_core/callable_provider.py
+++ b/src/promptise/identity/_core/callable_provider.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from .errors import TokenAcquisitionError
+from .errors import IdentityError, TokenAcquisitionError
 from .provider import IdentityProvider
 
 
@@ -67,12 +67,12 @@ class CallableTokenProvider(IdentityProvider):
     def _acquire_upstream_jwt(self) -> str:
         try:
             token = self._token_fn()
-        except TokenAcquisitionError:
-            # The callable already produced a precise, typed error
-            # (for example a metadata-service provider with its own
-            # diagnostic message). Let it propagate unchanged rather
-            # than wrapping it in a second, more generic
-            # TokenAcquisitionError.
+        except IdentityError:
+            # The callable already produced a precise, typed identity
+            # error — a TokenAcquisitionError from a metadata-service
+            # provider, or a ProviderConfigError from a missing optional
+            # dependency. Let it propagate unchanged rather than
+            # wrapping it in a second, more generic error.
             raise
         except Exception as exc:
             raise TokenAcquisitionError(

--- a/src/promptise/identity/_core/callable_provider.py
+++ b/src/promptise/identity/_core/callable_provider.py
@@ -1,0 +1,90 @@
+"""Callable-backed identity provider — invokes a function for the JWT.
+
+Used by:
+
+* AWS STS ``get_web_identity_token`` (wrapped in a callable inside
+  :class:`AwsStsProvider`).
+* GCP metadata server ``identity`` endpoint.
+* SPIFFE Workload API via :mod:`pyspiffe`.
+* Generic OIDC callable mode.
+
+Any exception raised by the user-supplied callable is wrapped in
+:class:`TokenAcquisitionError` with the provider label in the message
+and the underlying exception chained on ``__cause__``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .errors import TokenAcquisitionError
+from .provider import IdentityProvider
+
+
+class CallableTokenProvider(IdentityProvider):
+    """Invokes a user-supplied callable to acquire the upstream JWT.
+
+    Args:
+        token_fn: A zero-argument callable that returns the JWT as a
+            string. Called fresh on every refresh — caching the result
+            would defeat the upstream's own rotation.
+        provider_label: Short string used in log messages and error
+            output. Concrete provider subclasses (Entra IMDS, AWS STS,
+            GCP metadata, SPIFFE SDK, generic OIDC callable) pass
+            their own label.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_fn: Callable[[], str],
+        provider_label: str = "callable",
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+        self._token_fn: Callable[[], str] = token_fn
+        self._provider_label: str = provider_label
+
+    @property
+    def provider_name(self) -> str:
+        return self._provider_label
+
+    def _acquire_upstream_jwt(self) -> str:
+        try:
+            token = self._token_fn()
+        except Exception as exc:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] upstream JWT callable raised "
+                f"{type(exc).__name__}: {exc}. Most common cause: the cloud "
+                f"SDK or metadata service is unreachable from this workload."
+            ) from exc
+        if not isinstance(token, str):
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] upstream JWT callable returned "
+                f"{type(token).__name__}, expected str. Fix the callable to "
+                f"return the JWT as a string."
+            )
+        token = token.strip()
+        if not token:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] upstream JWT callable returned an "
+                f"empty string. Most common cause: the metadata service "
+                f"responded successfully but the JWT body was empty "
+                f"(transient issue, or a misconfigured audience parameter)."
+            )
+        return token

--- a/src/promptise/identity/_core/callable_provider.py
+++ b/src/promptise/identity/_core/callable_provider.py
@@ -67,6 +67,13 @@ class CallableTokenProvider(IdentityProvider):
     def _acquire_upstream_jwt(self) -> str:
         try:
             token = self._token_fn()
+        except TokenAcquisitionError:
+            # The callable already produced a precise, typed error
+            # (for example a metadata-service provider with its own
+            # diagnostic message). Let it propagate unchanged rather
+            # than wrapping it in a second, more generic
+            # TokenAcquisitionError.
+            raise
         except Exception as exc:
             raise TokenAcquisitionError(
                 f"[{self._provider_label}] upstream JWT callable raised "

--- a/src/promptise/identity/_core/errors.py
+++ b/src/promptise/identity/_core/errors.py
@@ -1,0 +1,88 @@
+"""Exception types for the ``promptise.identity`` subsystem.
+
+All identity-related exceptions inherit from :class:`IdentityError`,
+which inherits directly from :class:`Exception`. The framework's
+existing :mod:`promptise.exceptions` is scoped to the SuperAgent file
+loader and does not provide a base type that fits federated identity,
+so we root a new hierarchy here.
+
+Every message follows the existing Promptise error style: it names the
+operation that failed, explains the most common cause in one sentence,
+and points at the concrete fix.
+"""
+
+from __future__ import annotations
+
+
+class IdentityError(Exception):
+    """Base exception for every Agent Identity failure.
+
+    Catching :class:`IdentityError` catches every error raised by
+    ``promptise.identity`` regardless of which provider produced it.
+    """
+
+
+class TokenAcquisitionError(IdentityError):
+    """The upstream identity provider could not supply a JWT.
+
+    Most common causes:
+
+    * The platform metadata service (Azure IMDS, GCP metadata server,
+      AWS STS) is unreachable from this workload.
+    * The federated token file declared by an environment variable does
+      not exist or is not readable.
+    * A user-supplied callable raised an exception (the original
+      exception is chained on ``__cause__``).
+    * A required environment variable is unset.
+    """
+
+
+class TokenExchangeError(IdentityError):
+    """Anthropic rejected the JWT-bearer exchange.
+
+    Most common causes:
+
+    * The JWT's ``iss`` claim does not match the federation issuer URL
+      registered in the Anthropic Console.
+    * The federation rule, organization, or service-account ID is
+      wrong or has been removed.
+    * The audience claim in the JWT does not include
+      ``https://api.anthropic.com``.
+    * The JWT expired between acquisition and exchange (clock skew).
+    """
+
+
+class ProviderConfigError(IdentityError):
+    """An identity provider was misconfigured at construction time.
+
+    Most common causes:
+
+    * A required environment variable is unset and no override was
+      passed to the factory.
+    * Conflicting arguments were supplied (for example, both
+      ``token_file`` and ``token_fn`` to :func:`from_oidc`).
+    * A required optional dependency is missing — boto3 for AWS, or
+      pyspiffe for SPIFFE SDK mode. The exception message names the
+      exact ``pip install`` command that resolves it.
+    """
+
+
+class CredentialPrecedenceError(IdentityError):
+    """Both an :class:`AgentIdentity` and a static API key are configured.
+
+    The framework refuses to silently shadow one with the other. Either
+    unset ``ANTHROPIC_API_KEY`` or remove the ``identity=`` argument
+    from :func:`promptise.build_agent`.
+    """
+
+
+class PlatformDetectionError(IdentityError):
+    """:meth:`AgentIdentity.auto` could not detect a supported platform.
+
+    Most common cause: the process is running on a host that does not
+    expose a workload identity (a developer laptop, a bare VM without
+    managed identity, a container without service-account token
+    projection). Use one of the explicit factories — ``from_entra``,
+    ``from_aws``, ``from_gcp``, ``from_spiffe``, ``from_oidc`` —
+    instead of ``AgentIdentity.auto()``.
+    """

--- a/src/promptise/identity/_core/exchange.py
+++ b/src/promptise/identity/_core/exchange.py
@@ -1,0 +1,200 @@
+"""RFC 7523 JWT-bearer exchange against Anthropic's OAuth endpoint.
+
+This is the **only** module that knows the Anthropic OAuth URL and the
+RFC 7523 grant-type string. If Anthropic ever changes the protocol —
+new URL, new grant type, new response schema — this file is the only
+one that needs to be edited (build plan section 5.6).
+
+The exchange flow:
+
+1. The caller (an :class:`~promptise.identity.IdentityProvider`)
+   already holds a fresh upstream JWT obtained from the cloud
+   platform's metadata service, STS endpoint, or token file.
+2. :func:`exchange_jwt_for_anthropic_token` POSTs that JWT to
+   ``https://api.anthropic.com/v1/oauth/token`` using the grant type
+   ``urn:ietf:params:oauth:grant-type:jwt-bearer``.
+3. Anthropic returns a short-lived bearer token whose value starts
+   with ``sk-ant-oat01-``.
+4. The function returns a :class:`MintedToken` whose monotonic-clock
+   expiry the caller stores in its cache.
+
+The function uses :mod:`httpx` for the HTTP transport. ``httpx`` is
+already pulled in transitively by the Anthropic SDK, the OpenAI SDK,
+MCP, LangGraph, and roughly fifteen other packages Promptise depends
+on, so this is not a new top-level dependency (build plan section
+4.10).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from .._internal.logging import logger
+from .cache import MintedToken
+from .errors import TokenAcquisitionError, TokenExchangeError
+
+#: Anthropic's OAuth token endpoint. Hard-coded — overrides are not
+#: part of the v1.0 public API.
+_ANTHROPIC_OAUTH_TOKEN_ENDPOINT: str = "https://api.anthropic.com/v1/oauth/token"
+
+#: The RFC 7523 grant type the endpoint expects.
+_RFC_7523_GRANT_TYPE: str = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+#: Every workload-issued Anthropic access token must start with this
+#: prefix. A response that does not is treated as a protocol change
+#: and rejected — the framework refuses to handle an unrecognised
+#: credential format.
+_EXPECTED_ACCESS_TOKEN_PREFIX: str = "sk-ant-oat01-"
+
+
+def exchange_jwt_for_anthropic_token(
+    upstream_jwt: str,
+    *,
+    federation_rule_id: str,
+    organization_id: str,
+    service_account_id: str,
+    workspace_id: str | None,
+    timeout: float = 10.0,
+    provider_name: str = "identity",
+) -> MintedToken:
+    """Exchange an upstream JWT for a short-lived Anthropic access token.
+
+    Args:
+        upstream_jwt: The OIDC JWT obtained from the upstream identity
+            provider. The token's ``iss`` claim must match the
+            federation issuer URL registered in the Anthropic Console.
+        federation_rule_id: The ``fdrl_*`` identifier registered in the
+            Anthropic Console for this workload's federation.
+        organization_id: The Anthropic organization UUID.
+        service_account_id: The ``svac_*`` identifier of the workload's
+            service account.
+        workspace_id: Optional ``wrkspc_*`` identifier. When supplied
+            the minted token is scoped to a single workspace; when
+            omitted the token covers every workspace the service
+            account is authorised for.
+        timeout: Maximum seconds to wait for the exchange. Default
+            ten seconds — short enough to surface degraded networks
+            quickly, long enough to tolerate normal TLS handshakes
+            against ``api.anthropic.com``.
+        provider_name: Free-form short identifier used in log records
+            and error messages so operators can tell which provider
+            triggered an exchange.
+
+    Returns:
+        A :class:`MintedToken` whose ``expires_at_monotonic`` field is
+        derived from a :func:`time.monotonic` snapshot taken **before**
+        the HTTP request. This is intentionally conservative — the
+        token will be considered "expiring" slightly sooner than its
+        nominal lifetime, which is safer than the opposite mistake.
+
+    Raises:
+        TokenAcquisitionError: When the request times out or the
+            transport fails before a response is received.
+        TokenExchangeError: When Anthropic returns a non-2xx status,
+            a body without ``access_token``, an ``expires_in`` value
+            that is not an integer, or an access token that does not
+            start with the expected prefix.
+    """
+    payload: dict[str, Any] = {
+        "grant_type": _RFC_7523_GRANT_TYPE,
+        "assertion": upstream_jwt,
+        "federation_rule_id": federation_rule_id,
+        "organization_id": organization_id,
+        "service_account_id": service_account_id,
+    }
+    if workspace_id is not None:
+        payload["workspace_id"] = workspace_id
+
+    minted_at_monotonic = time.monotonic()
+    try:
+        response = httpx.post(
+            _ANTHROPIC_OAUTH_TOKEN_ENDPOINT,
+            json=payload,
+            timeout=timeout,
+        )
+    except httpx.TimeoutException as exc:
+        raise TokenAcquisitionError(
+            f"[{provider_name}] JWT-bearer exchange to "
+            f"{_ANTHROPIC_OAUTH_TOKEN_ENDPOINT} timed out after {timeout}s. "
+            f"Most common cause: outbound network access from this workload "
+            f"to api.anthropic.com is blocked. Verify the egress policy."
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise TokenAcquisitionError(
+            f"[{provider_name}] JWT-bearer exchange to "
+            f"{_ANTHROPIC_OAUTH_TOKEN_ENDPOINT} failed before a response was "
+            f"received ({type(exc).__name__}). Most common cause: TLS "
+            f"handshake or DNS failure. Underlying error: {exc}"
+        ) from exc
+
+    if response.status_code != 200:
+        raise TokenExchangeError(
+            f"[{provider_name}] Anthropic rejected the JWT-bearer exchange "
+            f"(HTTP {response.status_code}). Most common cause: the JWT's "
+            f"'iss' claim does not match the federation issuer URL "
+            f"registered in the Anthropic Console. Response body: "
+            f"{response.text}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise TokenExchangeError(
+            f"[{provider_name}] Anthropic returned a non-JSON body from "
+            f"{_ANTHROPIC_OAUTH_TOKEN_ENDPOINT} (HTTP "
+            f"{response.status_code}). Body preview: {response.text[:200]!r}"
+        ) from exc
+
+    access_token = body.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise TokenExchangeError(
+            f"[{provider_name}] Exchange response is missing the "
+            f"'access_token' field. Most common cause: Anthropic changed "
+            f"the OAuth response schema. Body keys: {list(body.keys())}"
+        )
+    if not access_token.startswith(_EXPECTED_ACCESS_TOKEN_PREFIX):
+        raise TokenExchangeError(
+            f"[{provider_name}] Anthropic access token does not start with "
+            f"{_EXPECTED_ACCESS_TOKEN_PREFIX!r}. Most common cause: "
+            f"Anthropic has changed the access-token format. If you are "
+            f"seeing this, the framework needs an update."
+        )
+
+    expires_in_raw = body.get("expires_in", 3600)
+    try:
+        expires_in_seconds = int(expires_in_raw)
+    except (TypeError, ValueError) as exc:
+        raise TokenExchangeError(
+            f"[{provider_name}] Exchange response 'expires_in' is not an "
+            f"integer: {expires_in_raw!r}. Most common cause: Anthropic "
+            f"changed the response schema."
+        ) from exc
+
+    token_type_raw = body.get("token_type", "Bearer")
+    token_type = token_type_raw if isinstance(token_type_raw, str) else "Bearer"
+
+    minted = MintedToken(
+        access_token=access_token,
+        token_type=token_type,
+        expires_at_monotonic=minted_at_monotonic + expires_in_seconds,
+        expires_in_seconds=expires_in_seconds,
+    )
+
+    scope = body.get("scope")
+    if isinstance(scope, str):
+        logger.info(
+            "Anthropic exchange ok provider=%s scope=%s expires_in=%d",
+            provider_name,
+            scope,
+            expires_in_seconds,
+        )
+    else:
+        logger.info(
+            "Anthropic exchange ok provider=%s expires_in=%d",
+            provider_name,
+            expires_in_seconds,
+        )
+    return minted

--- a/src/promptise/identity/_core/file_provider.py
+++ b/src/promptise/identity/_core/file_provider.py
@@ -1,0 +1,109 @@
+"""File-backed identity provider — reads a projected JWT on every refresh.
+
+Used by:
+
+* Kubernetes service-account token projection.
+* AKS Workload Identity (``$AZURE_FEDERATED_TOKEN_FILE``).
+* SPIFFE helper output (``spiffe-helper`` writes the JWT-SVID to a
+  file that the workload reads).
+* Generic OIDC file mode.
+
+The file is re-opened on every call to :meth:`_acquire_upstream_jwt`.
+Kubernetes and SPIRE rotate projected tokens **in place**; caching
+the contents in memory would defeat the rotation mechanism. This is
+architectural, not a tunable (build plan section 4.6).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .errors import TokenAcquisitionError
+from .provider import IdentityProvider
+
+
+class FileTokenProvider(IdentityProvider):
+    """Reads the upstream JWT from a file on disk on every refresh.
+
+    Args:
+        token_file: Filesystem path to the JWT file. The framework
+            re-opens this file on every refresh; the projection
+            mechanism (Kubernetes, AKS, ``spiffe-helper``) keeps it
+            up to date.
+        provider_label: Short string used in log messages and error
+            output. Concrete provider subclasses (Entra projected,
+            AWS EKS projected, SPIFFE file, generic OIDC file) pass
+            their own label.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_file: str | Path,
+        provider_label: str = "file",
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+        self._token_file: Path = Path(token_file)
+        self._provider_label: str = provider_label
+
+    @property
+    def provider_name(self) -> str:
+        return self._provider_label
+
+    @property
+    def token_file(self) -> Path:
+        """Path of the projected JWT file (read-only access)."""
+        return self._token_file
+
+    def _acquire_upstream_jwt(self) -> str:
+        try:
+            with self._token_file.open("r", encoding="utf-8") as fh:
+                contents = fh.read()
+        except FileNotFoundError as exc:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] projected token file not found at "
+                f"{self._token_file}. Most common cause: the workload is not "
+                f"running with federated token projection enabled. Verify the "
+                f"platform's projection mechanism (Kubernetes service-account "
+                f"token volume, AKS Workload Identity admission webhook, or "
+                f"spiffe-helper) writes to this path."
+            ) from exc
+        except PermissionError as exc:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] projected token file at "
+                f"{self._token_file} is not readable. Most common cause: the "
+                f"process user does not match the file owner of the projected "
+                f"volume. Underlying error: {exc}"
+            ) from exc
+        except OSError as exc:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] could not read projected token "
+                f"file at {self._token_file} ({type(exc).__name__}): {exc}"
+            ) from exc
+
+        token = contents.strip()
+        if not token:
+            raise TokenAcquisitionError(
+                f"[{self._provider_label}] projected token file at "
+                f"{self._token_file} is empty. Most common cause: the "
+                f"projection volume was just created and the platform has "
+                f"not yet written the first token. Wait a few seconds and "
+                f"retry."
+            )
+        return token

--- a/src/promptise/identity/_core/provider.py
+++ b/src/promptise/identity/_core/provider.py
@@ -1,0 +1,159 @@
+""":class:`IdentityProvider` — caching, locking, and refresh logic.
+
+Every concrete identity provider subclasses :class:`IdentityProvider`
+and implements two members:
+
+* the :attr:`provider_name` property — a short string used in log
+  messages and error output;
+* the :meth:`_acquire_upstream_jwt` method — fetches a fresh JWT from
+  the cloud platform.
+
+Everything else lives on the base class: the cached
+:class:`MintedToken`, the :class:`threading.Lock` that serialises
+concurrent callers, and the two-tier refresh logic defined in section
+4.5 of the build plan.
+"""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+
+from .._internal.logging import logger
+from .cache import MintedToken
+from .errors import TokenAcquisitionError, TokenExchangeError
+from .exchange import exchange_jwt_for_anthropic_token
+
+
+class IdentityProvider(ABC):
+    """Abstract base for every federated identity provider.
+
+    A single :class:`IdentityProvider` instance is safe to share
+    across threads. Concurrent calls to :meth:`get_token` collapse
+    into one upstream JWT acquisition and one Anthropic exchange,
+    serialised by :attr:`_lock`. The cache is process-local — there
+    is no shared cache between workers in a multi-process deployment.
+    That trade-off is intentional (build plan section 4.4): sharing
+    minted tokens across processes is a security problem the framework
+    explicitly does not solve at this layer.
+
+    Args:
+        federation_rule_id: The ``fdrl_*`` identifier from the
+            Anthropic Console.
+        organization_id: The Anthropic organization UUID.
+        service_account_id: The ``svac_*`` identifier of the workload's
+            service account.
+        workspace_id: Optional ``wrkspc_*`` identifier. When supplied,
+            minted tokens are scoped to a single workspace.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+            Default ten seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        self.federation_rule_id: str = federation_rule_id
+        self.organization_id: str = organization_id
+        self.service_account_id: str = service_account_id
+        self.workspace_id: str | None = workspace_id
+        self.exchange_timeout: float = exchange_timeout
+        self._cached: MintedToken | None = None
+        self._lock: threading.Lock = threading.Lock()
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """A short identifier used in log messages and error output."""
+
+    @abstractmethod
+    def _acquire_upstream_jwt(self) -> str:
+        """Fetch a fresh upstream JWT from the cloud platform.
+
+        Subclasses call the platform's metadata service, SDK, or read
+        a projected token file. They return the JWT as a bare string;
+        the Anthropic exchange happens in :meth:`_refresh` of this base
+        class.
+
+        Raises:
+            TokenAcquisitionError: When the upstream IdP cannot supply
+                a JWT. Subclass implementations wrap their underlying
+                exception with ``raise … from exc`` so the original
+                cause stays attached to ``__cause__``.
+        """
+
+    def get_token(self) -> str:
+        """Return a currently-valid Anthropic access token.
+
+        Behaviour:
+
+        * If no token is cached, perform a mandatory refresh.
+        * If the cached token is inside the mandatory window
+          (≤ :data:`~promptise.identity.MANDATORY_REFRESH_BUFFER_SECONDS`
+          to expiry), perform a mandatory refresh. Any failure
+          propagates.
+        * If the cached token is inside the advisory window
+          (≤ :data:`~promptise.identity.ADVISORY_REFRESH_BUFFER_SECONDS`
+          to expiry) but outside the mandatory window, attempt a
+          refresh; on failure, log a warning and continue with the
+          cached token.
+        * Otherwise, return the cached token unchanged.
+
+        Returns:
+            A short-lived Anthropic access token (prefix
+            ``sk-ant-oat01-``).
+
+        Raises:
+            TokenAcquisitionError: When the upstream IdP fails AND a
+                mandatory refresh was required.
+            TokenExchangeError: When Anthropic rejects the exchange
+                AND a mandatory refresh was required.
+        """
+        with self._lock:
+            token = self._cached
+            if token is None or token.needs_mandatory_refresh():
+                self._cached = self._refresh()
+                return self._cached.access_token
+            if token.needs_advisory_refresh():
+                try:
+                    self._cached = self._refresh()
+                    return self._cached.access_token
+                except (TokenAcquisitionError, TokenExchangeError) as exc:
+                    logger.warning(
+                        "advisory refresh failed provider=%s reason=%s; "
+                        "continuing with cached token",
+                        self.provider_name,
+                        exc,
+                    )
+                    return token.access_token
+            return token.access_token
+
+    def get_auth_header(self) -> dict[str, str]:
+        """Return a ready-to-use ``Authorization`` header value.
+
+        Convenience for callers that need to attach a bearer token to
+        a downstream HTTP request (an MCP tool calling a third-party
+        API, an Anthropic SDK that accepts a custom header).
+
+        Returns:
+            A single-key dict ``{"Authorization": "Bearer <token>"}``.
+        """
+        return {"Authorization": f"Bearer {self.get_token()}"}
+
+    def _refresh(self) -> MintedToken:
+        """Acquire a fresh upstream JWT and exchange it for an access token."""
+        jwt = self._acquire_upstream_jwt()
+        return exchange_jwt_for_anthropic_token(
+            jwt,
+            federation_rule_id=self.federation_rule_id,
+            organization_id=self.organization_id,
+            service_account_id=self.service_account_id,
+            workspace_id=self.workspace_id,
+            timeout=self.exchange_timeout,
+            provider_name=self.provider_name,
+        )

--- a/src/promptise/identity/_internal/__init__.py
+++ b/src/promptise/identity/_internal/__init__.py
@@ -1,0 +1,7 @@
+"""Subsystem-internal helpers (logging, env resolution, platform detection).
+
+Nothing in here is part of the public API. Code outside
+``promptise.identity`` must not import from this package.
+"""
+
+from __future__ import annotations

--- a/src/promptise/identity/_internal/detect.py
+++ b/src/promptise/identity/_internal/detect.py
@@ -1,0 +1,98 @@
+"""Platform auto-detection for :meth:`AgentIdentity.auto`.
+
+A workload usually knows which cloud it runs on without being told —
+the runtime sets characteristic environment variables. This module
+reads those markers and returns a short platform identifier that
+:meth:`AgentIdentity.auto` dispatches on.
+
+The detection order (build plan section 5.13) follows the rough order
+of cloud market share among likely Promptise users, and is
+deterministic: when a workload sets markers for more than one platform
+(an AKS pod that also has AWS credentials mounted, say), the
+**first** match in the table wins. Entra precedes AWS precedes GCP
+precedes SPIFFE. No metadata-server probe is performed — detection is
+purely environment-variable based, so it is fast, side-effect free,
+and safe to call when offline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+from .._core.errors import PlatformDetectionError
+
+#: Platform identifier returned by :func:`detect_platform`.
+Platform = Literal["entra", "aws", "gcp", "spiffe"]
+
+#: Entra markers: AKS Workload Identity projects a token file; VM/MSI
+#: workloads expose the managed-identity client id.
+_ENTRA_ENV_VARS: tuple[str, ...] = (
+    "AZURE_FEDERATED_TOKEN_FILE",
+    "AZURE_CLIENT_ID",
+)
+
+#: AWS markers: Lambda, the generic execution-env stamp, the EKS pod
+#: name, and the EKS-projected web-identity token file.
+_AWS_ENV_VARS: tuple[str, ...] = (
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "AWS_EXECUTION_ENV",
+    "EKS_POD_NAME",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+)
+
+#: GCP markers: the project id, the Cloud Run service name, and the
+#: metadata-server IP hint.
+_GCP_ENV_VARS: tuple[str, ...] = (
+    "GOOGLE_CLOUD_PROJECT",
+    "K_SERVICE",
+    "GCE_METADATA_IP",
+)
+
+#: SPIFFE marker: the Workload API socket address.
+_SPIFFE_ENV_VARS: tuple[str, ...] = ("SPIFFE_ENDPOINT_SOCKET",)
+
+#: Ordered detection table. The first platform whose marker set has any
+#: variable present wins.
+_DETECTION_ORDER: tuple[tuple[Platform, tuple[str, ...]], ...] = (
+    ("entra", _ENTRA_ENV_VARS),
+    ("aws", _AWS_ENV_VARS),
+    ("gcp", _GCP_ENV_VARS),
+    ("spiffe", _SPIFFE_ENV_VARS),
+)
+
+
+def _any_env_set(names: tuple[str, ...]) -> bool:
+    """Return ``True`` if any of ``names`` is set to a non-empty value.
+
+    An environment variable set to the empty string counts as unset —
+    a common shape in CI systems that declare a variable without giving
+    it a value.
+    """
+    return any(os.environ.get(name) for name in names)
+
+
+def detect_platform() -> Platform:
+    """Detect the federation platform from environment markers.
+
+    Returns:
+        One of ``"entra"``, ``"aws"``, ``"gcp"``, or ``"spiffe"`` — the
+        first platform in the detection order whose markers are present.
+
+    Raises:
+        PlatformDetectionError: When no platform marker is found. The
+            message names every platform that was probed and points at
+            the explicit ``from_*`` factories as the fallback.
+    """
+    for identifier, env_vars in _DETECTION_ORDER:
+        if _any_env_set(env_vars):
+            return identifier
+    raise PlatformDetectionError(
+        "could not auto-detect a federation platform: no Entra, AWS, "
+        "GCP, or SPIFFE environment markers were found. Most common "
+        "cause: AgentIdentity.auto() was called off-platform (a laptop "
+        "or a generic CI runner). Set the platform's environment "
+        "variables, or construct the provider explicitly with "
+        "AgentIdentity.from_entra(), .from_aws(), .from_gcp(), "
+        ".from_spiffe(), or .from_oidc()."
+    )

--- a/src/promptise/identity/_internal/env.py
+++ b/src/promptise/identity/_internal/env.py
@@ -1,0 +1,99 @@
+"""Environment-variable helpers for federation configuration.
+
+Every provider factory needs the four Anthropic federation identifiers
+(rule, organization, service account, optional workspace). They are
+read from environment variables by convention, with explicit
+constructor arguments overriding any environment value.
+
+This module centralises the resolution so each factory contains
+exactly one line of credential plumbing.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .._core.errors import ProviderConfigError
+
+#: Environment variable holding the ``fdrl_*`` federation rule ID.
+ENV_FEDERATION_RULE_ID: str = "ANTHROPIC_FEDERATION_RULE_ID"
+
+#: Environment variable holding the Anthropic organization UUID.
+ENV_ORGANIZATION_ID: str = "ANTHROPIC_ORGANIZATION_ID"
+
+#: Environment variable holding the ``svac_*`` service-account ID.
+ENV_SERVICE_ACCOUNT_ID: str = "ANTHROPIC_SERVICE_ACCOUNT_ID"
+
+#: Environment variable holding the optional ``wrkspc_*`` workspace ID.
+ENV_WORKSPACE_ID: str = "ANTHROPIC_WORKSPACE_ID"
+
+
+def _require_env(name: str) -> str:
+    """Return the value of ``name`` or raise :class:`ProviderConfigError`.
+
+    Args:
+        name: The environment variable to read.
+
+    Returns:
+        The whitespace-stripped value.
+
+    Raises:
+        ProviderConfigError: If ``name`` is unset or contains only
+            whitespace. The exception message names the variable and
+            points at the matching factory argument.
+    """
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        raise ProviderConfigError(
+            f"Required environment variable {name} is not set. Either set it "
+            f"in the workload's environment or pass the equivalent argument "
+            f"to the factory (federation_rule_id=..., organization_id=..., "
+            f"service_account_id=...). Most common cause: the variable was "
+            f"set in the developer's shell but not in the deployed "
+            f"environment."
+        )
+    return value.strip()
+
+
+def _resolve_anthropic_credentials(
+    *,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, str | None]:
+    """Resolve the four Anthropic federation identifiers.
+
+    Explicit overrides win. Each missing identifier (except the
+    optional ``workspace_id``) is read from its environment variable
+    via :func:`_require_env`, raising :class:`ProviderConfigError`
+    when absent.
+
+    Args:
+        federation_rule_id: Override for
+            :data:`ENV_FEDERATION_RULE_ID`.
+        organization_id: Override for :data:`ENV_ORGANIZATION_ID`.
+        service_account_id: Override for
+            :data:`ENV_SERVICE_ACCOUNT_ID`.
+        workspace_id: Override for :data:`ENV_WORKSPACE_ID`. Optional
+            in every code path.
+
+    Returns:
+        A dict with keys ``federation_rule_id``, ``organization_id``,
+        ``service_account_id``, ``workspace_id``. The first three are
+        always non-empty strings; the fourth is ``None`` when neither
+        the override nor the environment variable supplies a value.
+    """
+    fed = federation_rule_id if federation_rule_id else _require_env(ENV_FEDERATION_RULE_ID)
+    org = organization_id if organization_id else _require_env(ENV_ORGANIZATION_ID)
+    svc = service_account_id if service_account_id else _require_env(ENV_SERVICE_ACCOUNT_ID)
+    if workspace_id is None:
+        env_value = os.environ.get(ENV_WORKSPACE_ID)
+        if env_value is not None and env_value.strip():
+            workspace_id = env_value.strip()
+    return {
+        "federation_rule_id": fed,
+        "organization_id": org,
+        "service_account_id": svc,
+        "workspace_id": workspace_id,
+    }

--- a/src/promptise/identity/_internal/logging.py
+++ b/src/promptise/identity/_internal/logging.py
@@ -1,0 +1,31 @@
+"""Logger configuration for ``promptise.identity``.
+
+The subsystem uses a single root logger — ``promptise.identity`` —
+and follows the standard library logging convention of installing a
+:class:`logging.NullHandler` at import time so application code, not
+the framework, decides whether log output is emitted.
+
+Sub-loggers (``promptise.identity.aws``, ``promptise.identity.entra``,
+etc.) created via :func:`logging.getLogger` inherit from this root.
+"""
+
+from __future__ import annotations
+
+import logging
+
+#: The single root logger for the identity subsystem.
+logger: logging.Logger = logging.getLogger("promptise.identity")
+
+
+def _configure_default_handler() -> None:
+    """Install a :class:`logging.NullHandler` on the root logger.
+
+    Idempotent — repeated calls add no extra handlers. Called once
+    from :mod:`promptise.identity.__init__` so the library does not
+    emit "no handlers could be found" warnings when used in an
+    application that does not configure logging.
+    """
+    for existing in logger.handlers:
+        if isinstance(existing, logging.NullHandler):
+            return
+    logger.addHandler(logging.NullHandler())

--- a/src/promptise/identity/agent_identity.py
+++ b/src/promptise/identity/agent_identity.py
@@ -1,0 +1,476 @@
+"""The :class:`AgentIdentity` public class — the entire user surface.
+
+Everything a developer touches goes through one class. Five
+classmethod factories — one per supported IdP family — plus
+:meth:`AgentIdentity.auto` for environment-based platform detection.
+Each factory wraps the corresponding ``from_*`` function from the
+:mod:`promptise.identity.providers` package and returns an
+``AgentIdentity`` holding a single :class:`IdentityProvider`.
+
+The class is a deliberately thin wrapper. It forwards
+:meth:`get_token`, :meth:`get_auth_header`, :meth:`get_upstream_jwt`,
+and the federation identifiers to the underlying provider. The wrapper
+exists for forward compatibility: future cross-cutting features —
+audit-log enrichment, token-claim inspection, metrics — attach to
+``AgentIdentity`` without changing the provider classes or the public
+import path.
+
+Typical use is one line at the call site::
+
+    from promptise.identity import AgentIdentity
+
+    identity = AgentIdentity.from_aws()      # zero args, reads env
+    token = identity.get_token()             # exchanged + cached
+
+or, when the platform is not known ahead of time::
+
+    identity = AgentIdentity.auto()          # detects the cloud
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+from ._core.provider import IdentityProvider
+from ._internal.detect import detect_platform
+from .providers.aws import _DEFAULT_AUDIENCE as _AWS_DEFAULT_AUDIENCE
+from .providers.aws import _DEFAULT_SIGNING_ALGORITHM as _AWS_DEFAULT_SIGNING_ALGORITHM
+from .providers.aws import from_aws as _from_aws
+from .providers.entra import _DEFAULT_RESOURCE as _ENTRA_DEFAULT_RESOURCE
+from .providers.entra import from_entra as _from_entra
+from .providers.gcp import _DEFAULT_AUDIENCE as _GCP_DEFAULT_AUDIENCE
+from .providers.gcp import (
+    _DEFAULT_SERVICE_ACCOUNT_EMAIL as _GCP_DEFAULT_SERVICE_ACCOUNT_EMAIL,
+)
+from .providers.gcp import from_gcp as _from_gcp
+from .providers.oidc import from_oidc as _from_oidc
+from .providers.spiffe import _DEFAULT_AUDIENCE as _SPIFFE_DEFAULT_AUDIENCE
+from .providers.spiffe import from_spiffe as _from_spiffe
+
+#: Default Anthropic exchange timeout in seconds, shared across every
+#: factory. Mirrors :class:`IdentityProvider`'s own default.
+_DEFAULT_EXCHANGE_TIMEOUT: float = 10.0
+
+#: Default metadata-server timeout for GCP, in seconds.
+_DEFAULT_GCP_REQUEST_TIMEOUT: float = 5.0
+
+
+class AgentIdentity:
+    """A federated workload identity for an AI agent.
+
+    Holds one :class:`IdentityProvider` and forwards the token-minting
+    surface to it. Construct one with a factory classmethod rather than
+    calling ``__init__`` directly:
+
+    * :meth:`from_entra` — Microsoft Entra ID (IMDS or projected token)
+    * :meth:`from_aws` — AWS IAM (STS or EKS-projected token)
+    * :meth:`from_gcp` — Google Cloud (compute metadata server)
+    * :meth:`from_spiffe` — SPIFFE / SPIRE (Workload API or file)
+    * :meth:`from_oidc` — any standards-compliant OIDC issuer
+    * :meth:`auto` — detect the platform from the environment
+
+    A single instance is thread-safe and caches the minted Anthropic
+    token internally (see :class:`IdentityProvider`).
+
+    Args:
+        provider: The underlying identity provider. Prefer the factory
+            classmethods; pass a provider directly only when wrapping a
+            custom :class:`IdentityProvider` subclass.
+    """
+
+    def __init__(self, provider: IdentityProvider) -> None:
+        self._provider: IdentityProvider = provider
+
+    # -- Forwarded identity surface --------------------------------------
+
+    @property
+    def provider(self) -> IdentityProvider:
+        """The wrapped :class:`IdentityProvider` (advanced use)."""
+        return self._provider
+
+    @property
+    def provider_name(self) -> str:
+        """The provider's short label, e.g. ``"aws-sts"`` (for logs)."""
+        return self._provider.provider_name
+
+    @property
+    def federation_rule_id(self) -> str:
+        """The ``fdrl_*`` federation rule identifier."""
+        return self._provider.federation_rule_id
+
+    @property
+    def organization_id(self) -> str:
+        """The Anthropic organization UUID."""
+        return self._provider.organization_id
+
+    @property
+    def service_account_id(self) -> str:
+        """The ``svac_*`` service-account identifier."""
+        return self._provider.service_account_id
+
+    @property
+    def workspace_id(self) -> str | None:
+        """The optional ``wrkspc_*`` workspace identifier."""
+        return self._provider.workspace_id
+
+    def get_token(self) -> str:
+        """Return a currently-valid Anthropic access token.
+
+        Delegates to :meth:`IdentityProvider.get_token`, which performs
+        the two-tier refresh and caches the result.
+
+        Returns:
+            A short-lived Anthropic access token (``sk-ant-oat01-`` …).
+        """
+        return self._provider.get_token()
+
+    def get_auth_header(self) -> dict[str, str]:
+        """Return a ready-to-use ``Authorization`` bearer header.
+
+        Returns:
+            ``{"Authorization": "Bearer <token>"}``.
+        """
+        return self._provider.get_auth_header()
+
+    def get_upstream_jwt(self) -> str:
+        """Return a fresh upstream OIDC JWT from the cloud platform.
+
+        This is the value the Anthropic SDK exchanges itself when an
+        ``AgentIdentity`` is wired into ``build_agent()`` — the SDK
+        calls this to obtain a JWT and runs its own exchange and
+        refresh. It bypasses the framework's own token cache; callers
+        that want the exchanged Anthropic token use :meth:`get_token`.
+
+        Returns:
+            A bare upstream JWT string.
+
+        Raises:
+            TokenAcquisitionError: When the platform cannot supply a JWT.
+            ProviderConfigError: When a required optional SDK is missing.
+        """
+        return self._provider._acquire_upstream_jwt()
+
+    def __repr__(self) -> str:
+        """Return an identifier-only repr — never includes a token."""
+        workspace = (
+            f", workspace_id={self.workspace_id!r}" if self.workspace_id else ""
+        )
+        return (
+            f"AgentIdentity(provider={self.provider_name!r}, "
+            f"service_account_id={self.service_account_id!r}{workspace})"
+        )
+
+    # -- Factories -------------------------------------------------------
+
+    @classmethod
+    def from_entra(
+        cls,
+        *,
+        mode: Literal["auto", "imds", "projected"] = "auto",
+        client_id: str | None = None,
+        token_file: str | Path | None = None,
+        resource: str = _ENTRA_DEFAULT_RESOURCE,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Build a Microsoft Entra ID identity.
+
+        Args:
+            mode: ``"auto"`` (default) picks projected-token mode when
+                ``$AZURE_FEDERATED_TOKEN_FILE`` is set, otherwise IMDS.
+                Force a mode with ``"imds"`` or ``"projected"``.
+            client_id: Managed-identity client id (IMDS mode). Falls
+                back to ``$AZURE_CLIENT_ID``.
+            token_file: Projected token path. Falls back to
+                ``$AZURE_FEDERATED_TOKEN_FILE``.
+            resource: Resource/audience requested from IMDS.
+            federation_rule_id: ``fdrl_*``; falls back to
+                ``$ANTHROPIC_FEDERATION_RULE_ID``.
+            organization_id: Org UUID; falls back to
+                ``$ANTHROPIC_ORGANIZATION_ID``.
+            service_account_id: ``svac_*``; falls back to
+                ``$ANTHROPIC_SERVICE_ACCOUNT_ID``.
+            workspace_id: Optional ``wrkspc_*``; falls back to
+                ``$ANTHROPIC_WORKSPACE_ID``.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` wrapping the selected Entra provider.
+        """
+        return cls(
+            _from_entra(
+                mode=mode,
+                client_id=client_id,
+                token_file=token_file,
+                resource=resource,
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        )
+
+    @classmethod
+    def from_aws(
+        cls,
+        *,
+        mode: Literal["auto", "sts", "projected"] = "auto",
+        region: str | None = None,
+        token_file: str | Path | None = None,
+        audience: str = _AWS_DEFAULT_AUDIENCE,
+        signing_algorithm: str = _AWS_DEFAULT_SIGNING_ALGORITHM,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Build an AWS IAM identity.
+
+        Args:
+            mode: ``"auto"`` (default) picks EKS-projected mode when
+                ``$ANTHROPIC_IDENTITY_TOKEN_FILE`` is set, otherwise STS.
+                Force a mode with ``"sts"`` or ``"projected"``.
+            region: AWS region for STS. Falls back to ``$AWS_REGION``
+                then ``$AWS_DEFAULT_REGION``. Required for STS mode.
+            token_file: EKS-projected token path. Falls back to
+                ``$ANTHROPIC_IDENTITY_TOKEN_FILE`` then the default mount.
+            audience: Audience requested in the web-identity token.
+            signing_algorithm: STS signing algorithm (e.g. ``"RS256"``).
+            federation_rule_id: ``fdrl_*``; env fallback as above.
+            organization_id: Org UUID; env fallback as above.
+            service_account_id: ``svac_*``; env fallback as above.
+            workspace_id: Optional ``wrkspc_*``; env fallback as above.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` wrapping the selected AWS provider.
+        """
+        return cls(
+            _from_aws(
+                mode=mode,
+                region=region,
+                token_file=token_file,
+                audience=audience,
+                signing_algorithm=signing_algorithm,
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        )
+
+    @classmethod
+    def from_gcp(
+        cls,
+        *,
+        audience: str = _GCP_DEFAULT_AUDIENCE,
+        service_account_email: str = _GCP_DEFAULT_SERVICE_ACCOUNT_EMAIL,
+        request_timeout: float = _DEFAULT_GCP_REQUEST_TIMEOUT,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Build a Google Cloud identity.
+
+        Args:
+            audience: Audience requested in the identity token.
+            service_account_email: Attached service account whose
+                identity to request. ``"default"`` selects the
+                instance's primary account.
+            request_timeout: Seconds to wait for the metadata response.
+            federation_rule_id: ``fdrl_*``; env fallback as above.
+            organization_id: Org UUID; env fallback as above.
+            service_account_id: Anthropic ``svac_*`` (distinct from the
+                GCP ``service_account_email``); env fallback as above.
+            workspace_id: Optional ``wrkspc_*``; env fallback as above.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` wrapping the GCP metadata provider.
+        """
+        return cls(
+            _from_gcp(
+                audience=audience,
+                service_account_email=service_account_email,
+                request_timeout=request_timeout,
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        )
+
+    @classmethod
+    def from_spiffe(
+        cls,
+        *,
+        mode: Literal["auto", "file", "sdk"] = "auto",
+        token_file: str | Path | None = None,
+        socket_path: str | None = None,
+        audience: str = _SPIFFE_DEFAULT_AUDIENCE,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Build a SPIFFE / SPIRE identity.
+
+        Args:
+            mode: ``"auto"`` (default) picks file mode when
+                ``token_file`` is supplied, otherwise SDK mode. Force a
+                mode with ``"file"`` or ``"sdk"``.
+            token_file: JWT-SVID path written by ``spiffe-helper`` (file
+                mode). Required when ``mode="file"``.
+            socket_path: SPIRE Workload API socket (SDK mode). Falls back
+                to ``$SPIFFE_ENDPOINT_SOCKET`` then the default socket.
+            audience: Audience requested in the JWT-SVID (SDK mode).
+            federation_rule_id: ``fdrl_*``; env fallback as above.
+            organization_id: Org UUID; env fallback as above.
+            service_account_id: ``svac_*``; env fallback as above.
+            workspace_id: Optional ``wrkspc_*``; env fallback as above.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` wrapping the selected SPIFFE provider.
+        """
+        return cls(
+            _from_spiffe(
+                mode=mode,
+                token_file=token_file,
+                socket_path=socket_path,
+                audience=audience,
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        )
+
+    @classmethod
+    def from_oidc(
+        cls,
+        issuer: str,
+        *,
+        token_file: str | Path | None = None,
+        token_fn: Callable[[], str] | None = None,
+        token_env_var: str | None = None,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Build a generic OIDC identity.
+
+        Exactly one of ``token_file``, ``token_fn``, or
+        ``token_env_var`` must be supplied — they are the three ways to
+        obtain the issuer's JWT.
+
+        Args:
+            issuer: The OIDC issuer URL (recorded for observability).
+            token_file: Path to a file holding the JWT.
+            token_fn: Zero-arg callable returning the JWT.
+            token_env_var: Name of an env var holding the JWT (re-read
+                on every refresh).
+            federation_rule_id: ``fdrl_*``; env fallback as above.
+            organization_id: Org UUID; env fallback as above.
+            service_account_id: ``svac_*``; env fallback as above.
+            workspace_id: Optional ``wrkspc_*``; env fallback as above.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` wrapping the selected OIDC provider.
+        """
+        return cls(
+            _from_oidc(
+                issuer,
+                token_file=token_file,
+                token_fn=token_fn,
+                token_env_var=token_env_var,
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        )
+
+    @classmethod
+    def auto(
+        cls,
+        *,
+        federation_rule_id: str | None = None,
+        organization_id: str | None = None,
+        service_account_id: str | None = None,
+        workspace_id: str | None = None,
+        exchange_timeout: float = _DEFAULT_EXCHANGE_TIMEOUT,
+    ) -> AgentIdentity:
+        """Detect the platform from the environment and build an identity.
+
+        Uses :func:`promptise.identity._internal.detect.detect_platform`
+        to inspect platform environment markers, then dispatches to the
+        matching factory with platform defaults (auto sub-mode, default
+        audience, SDK mode for SPIFFE). Only the federation identifiers
+        and the exchange timeout are forwarded; per-platform tunables
+        keep their defaults.
+
+        Args:
+            federation_rule_id: ``fdrl_*``; env fallback as above.
+            organization_id: Org UUID; env fallback as above.
+            service_account_id: ``svac_*``; env fallback as above.
+            workspace_id: Optional ``wrkspc_*``; env fallback as above.
+            exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+        Returns:
+            An ``AgentIdentity`` for the detected platform.
+
+        Raises:
+            PlatformDetectionError: When no platform marker is present.
+        """
+        platform = detect_platform()
+        if platform == "entra":
+            return cls.from_entra(
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        if platform == "aws":
+            return cls.from_aws(
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        if platform == "gcp":
+            return cls.from_gcp(
+                federation_rule_id=federation_rule_id,
+                organization_id=organization_id,
+                service_account_id=service_account_id,
+                workspace_id=workspace_id,
+                exchange_timeout=exchange_timeout,
+            )
+        # The only remaining identifier from detect_platform() is "spiffe";
+        # detect_platform raises rather than return anything else.
+        return cls.from_spiffe(
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )

--- a/src/promptise/identity/providers/__init__.py
+++ b/src/promptise/identity/providers/__init__.py
@@ -1,0 +1,11 @@
+"""Provider implementations — one module per identity-provider family.
+
+Each module exposes its concrete provider classes plus a ``from_*``
+factory. The factories are wrapped by
+:class:`promptise.identity.AgentIdentity` classmethods; advanced users
+may also call them directly. Nothing in this package should be
+imported by code outside ``promptise.identity`` — use the top-level
+``promptise.identity`` namespace.
+"""
+
+from __future__ import annotations

--- a/src/promptise/identity/providers/aws.py
+++ b/src/promptise/identity/providers/aws.py
@@ -1,0 +1,288 @@
+"""AWS IAM identity provider.
+
+Two acquisition modes:
+
+* **STS GetWebIdentityToken** — for Lambda, EC2, ECS, and EKS workloads
+  with an IAM role. Lazily imports boto3 and calls STS to mint an OIDC
+  web-identity token scoped to the Anthropic audience.
+* **EKS projected token** — reads a projected federated token from
+  ``$ANTHROPIC_IDENTITY_TOKEN_FILE`` (default
+  ``/var/run/secrets/anthropic.com/token``).
+
+boto3 is an *optional* dependency (``pip install promptise[identity-aws]``).
+The STS provider imports it inside the acquisition method, never at
+module top, so a workload that only uses the EKS-projected mode — or
+only uses a different cloud — does not need boto3 installed. When the
+import fails the provider raises :class:`ProviderConfigError` naming the
+exact install command.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from .._core.callable_provider import CallableTokenProvider
+from .._core.errors import ProviderConfigError, TokenAcquisitionError
+from .._core.file_provider import FileTokenProvider
+from .._internal.env import _resolve_anthropic_credentials
+
+#: Environment variable naming the projected federated-token file.
+ENV_ANTHROPIC_IDENTITY_TOKEN_FILE: str = "ANTHROPIC_IDENTITY_TOKEN_FILE"
+
+#: Default projected-token path when the env var is unset.
+DEFAULT_ANTHROPIC_IDENTITY_TOKEN_FILE: str = "/var/run/secrets/anthropic.com/token"
+
+#: Environment variables AWS uses to expose the active region.
+ENV_AWS_REGION: str = "AWS_REGION"
+ENV_AWS_DEFAULT_REGION: str = "AWS_DEFAULT_REGION"
+
+#: Default audience requested from STS.
+_DEFAULT_AUDIENCE: str = "https://api.anthropic.com"
+
+#: Default JWT signing algorithm requested from STS.
+_DEFAULT_SIGNING_ALGORITHM: str = "RS256"
+
+#: The exact install command surfaced when boto3 is missing.
+_INSTALL_HINT: str = "pip install promptise[identity-aws]"
+
+
+class AwsStsProvider(CallableTokenProvider):
+    """AWS STS web-identity-token provider (lazily imports boto3).
+
+    STS is regional, so a region is required. It is resolved from the
+    ``region`` argument, then ``AWS_REGION``, then ``AWS_DEFAULT_REGION``.
+
+    Args:
+        region: AWS region for the STS client. Falls back to
+            ``AWS_REGION`` / ``AWS_DEFAULT_REGION``.
+        audience: Audience to request in the web-identity token.
+            Defaults to ``https://api.anthropic.com``.
+        signing_algorithm: JWT signing algorithm STS should use.
+            Defaults to ``RS256``.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+
+    Raises:
+        ProviderConfigError: At construction, if no region can be
+            resolved.
+    """
+
+    def __init__(
+        self,
+        *,
+        region: str | None = None,
+        audience: str = _DEFAULT_AUDIENCE,
+        signing_algorithm: str = _DEFAULT_SIGNING_ALGORITHM,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        resolved_region = (
+            region
+            or os.environ.get(ENV_AWS_REGION)
+            or os.environ.get(ENV_AWS_DEFAULT_REGION)
+        )
+        if not resolved_region:
+            raise ProviderConfigError(
+                "AWS STS is regional but no region was supplied. Pass "
+                "region='us-east-1' (or your region) or set AWS_REGION / "
+                "AWS_DEFAULT_REGION in the environment. Most common cause: "
+                "constructing the provider outside a configured AWS runtime."
+            )
+        self._region: str = resolved_region
+        self._audience: str = audience
+        self._signing_algorithm: str = signing_algorithm
+        super().__init__(
+            token_fn=self._fetch_sts_web_identity_token,
+            provider_label="aws-sts",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+    def _fetch_sts_web_identity_token(self) -> str:
+        """Mint an OIDC web-identity token via STS.
+
+        Lazily imports boto3 (principle 4.2). Raises
+        :class:`ProviderConfigError` when boto3 is missing and
+        :class:`TokenAcquisitionError` when the STS call itself fails;
+        both propagate through the base unchanged.
+        """
+        try:
+            import boto3  # noqa: E402  -- lazy import is intentional (4.2)
+        except ImportError as exc:
+            raise ProviderConfigError(
+                f"[aws-sts] AWS STS mode requires boto3, which is not "
+                f"installed. Install it with: {_INSTALL_HINT}. A workload "
+                f"that only uses the EKS-projected mode does not need boto3."
+            ) from exc
+
+        try:
+            client = boto3.client("sts", region_name=self._region)
+            response: dict[str, Any] = client.get_web_identity_token(
+                Audience=[self._audience],
+                SigningAlgorithm=self._signing_algorithm,
+            )
+        except Exception as exc:
+            raise TokenAcquisitionError(
+                f"[aws-sts] STS GetWebIdentityToken failed "
+                f"({type(exc).__name__}: {exc}). Most common cause: this "
+                f"workload has no IAM role attached, the role lacks "
+                f"sts:GetWebIdentityToken permission, or the region "
+                f"{self._region!r} is wrong."
+            ) from exc
+
+        token = response.get("WebIdentityToken")
+        if not isinstance(token, str) or not token:
+            raise TokenAcquisitionError(
+                f"[aws-sts] STS response did not contain a WebIdentityToken "
+                f"string. Most common cause: AWS changed the "
+                f"GetWebIdentityToken response schema. Response keys: "
+                f"{list(response.keys())}"
+            )
+        return token
+
+
+class AwsEksProjectedProvider(FileTokenProvider):
+    """AWS EKS projected-token provider.
+
+    Reads a projected federated token from
+    ``$ANTHROPIC_IDENTITY_TOKEN_FILE`` (default
+    ``/var/run/secrets/anthropic.com/token``). Requires no boto3.
+
+    Args:
+        token_file: Projected-token path. Defaults to
+            ``$ANTHROPIC_IDENTITY_TOKEN_FILE`` or, if unset,
+            :data:`DEFAULT_ANTHROPIC_IDENTITY_TOKEN_FILE`.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_file: str | Path | None = None,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        resolved_path: str | Path
+        if token_file is not None:
+            resolved_path = token_file
+        else:
+            resolved_path = os.environ.get(
+                ENV_ANTHROPIC_IDENTITY_TOKEN_FILE,
+                DEFAULT_ANTHROPIC_IDENTITY_TOKEN_FILE,
+            )
+        super().__init__(
+            token_file=resolved_path,
+            provider_label="aws-eks-projected",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+
+def from_aws(
+    *,
+    mode: Literal["auto", "sts", "projected"] = "auto",
+    region: str | None = None,
+    token_file: str | Path | None = None,
+    audience: str = _DEFAULT_AUDIENCE,
+    signing_algorithm: str = _DEFAULT_SIGNING_ALGORITHM,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+    exchange_timeout: float = 10.0,
+) -> AwsStsProvider | AwsEksProjectedProvider:
+    """Build an AWS IAM identity provider.
+
+    Args:
+        mode: ``"auto"`` (default) picks projected when
+            ``ANTHROPIC_IDENTITY_TOKEN_FILE`` is set, otherwise STS.
+            Force a mode with ``"sts"`` or ``"projected"``.
+        region: AWS region for STS mode. Falls back to ``AWS_REGION`` /
+            ``AWS_DEFAULT_REGION``.
+        token_file: Projected-token path for projected mode. Falls back
+            to ``$ANTHROPIC_IDENTITY_TOKEN_FILE``.
+        audience: Audience for the STS web-identity token (STS mode).
+        signing_algorithm: JWT signing algorithm for STS (STS mode).
+        federation_rule_id: The ``fdrl_*`` identifier. Falls back to
+            ``ANTHROPIC_FEDERATION_RULE_ID``.
+        organization_id: The organization UUID. Falls back to
+            ``ANTHROPIC_ORGANIZATION_ID``.
+        service_account_id: The ``svac_*`` identifier. Falls back to
+            ``ANTHROPIC_SERVICE_ACCOUNT_ID``.
+        workspace_id: Optional ``wrkspc_*`` identifier. Falls back to
+            ``ANTHROPIC_WORKSPACE_ID``.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+    Returns:
+        An :class:`AwsStsProvider` for STS mode or an
+        :class:`AwsEksProjectedProvider` for projected mode.
+
+    Raises:
+        ProviderConfigError: If ``mode`` is not ``auto``/``sts``/
+            ``projected``, if STS mode cannot resolve a region, or if a
+            required federation identifier is unset.
+    """
+    resolved_mode = mode
+    if resolved_mode == "auto":
+        resolved_mode = (
+            "projected"
+            if os.environ.get(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE)
+            else "sts"
+        )
+
+    creds = _resolve_anthropic_credentials(
+        federation_rule_id=federation_rule_id,
+        organization_id=organization_id,
+        service_account_id=service_account_id,
+        workspace_id=workspace_id,
+    )
+    fed = cast(str, creds["federation_rule_id"])
+    org = cast(str, creds["organization_id"])
+    svc = cast(str, creds["service_account_id"])
+    ws = creds["workspace_id"]
+
+    if resolved_mode == "projected":
+        return AwsEksProjectedProvider(
+            token_file=token_file,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    if resolved_mode == "sts":
+        return AwsStsProvider(
+            region=region,
+            audience=audience,
+            signing_algorithm=signing_algorithm,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    raise ProviderConfigError(
+        f"Unknown AWS mode {mode!r}. Valid modes are 'auto', 'sts', and "
+        f"'projected'."
+    )

--- a/src/promptise/identity/providers/entra.py
+++ b/src/promptise/identity/providers/entra.py
@@ -1,0 +1,295 @@
+"""Microsoft Entra ID identity provider.
+
+Two acquisition modes:
+
+* **Managed identity (IMDS)** — for Azure VMs, VM Scale Sets, and other
+  compute with a system- or user-assigned managed identity. Calls the
+  Azure Instance Metadata Service and extracts the OIDC ``id_token``
+  (not the ``access_token`` — the ``id_token`` is the federation
+  assertion).
+* **Projected token (AKS Workload Identity)** — for AKS pods using the
+  Workload Identity admission webhook, which projects a federated token
+  to the file named by ``$AZURE_FEDERATED_TOKEN_FILE`` (default
+  ``/var/run/secrets/azure/tokens/azure-identity-token``).
+
+The :func:`from_entra` factory's ``auto`` mode selects projected when
+``AZURE_FEDERATED_TOKEN_FILE`` is present (the signal that the workload
+runs under AKS Workload Identity), and IMDS otherwise.
+
+Entra needs no cloud SDK — IMDS is a plain HTTP GET — so there is no
+optional dependency for this provider.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal, cast
+
+import httpx
+
+from .._core.callable_provider import CallableTokenProvider
+from .._core.errors import ProviderConfigError, TokenAcquisitionError
+from .._core.file_provider import FileTokenProvider
+from .._internal.env import _resolve_anthropic_credentials
+
+#: Azure Instance Metadata Service token endpoint (link-local address).
+_IMDS_TOKEN_ENDPOINT: str = "http://169.254.169.254/metadata/identity/oauth2/token"
+
+#: Environment variable AKS Workload Identity sets to the projected
+#: token file path.
+ENV_AZURE_FEDERATED_TOKEN_FILE: str = "AZURE_FEDERATED_TOKEN_FILE"
+
+#: Default projected-token path used when the env var is unset.
+DEFAULT_AZURE_FEDERATED_TOKEN_FILE: str = (
+    "/var/run/secrets/azure/tokens/azure-identity-token"
+)
+
+#: Default resource (audience) requested from IMDS.
+_DEFAULT_RESOURCE: str = "https://api.anthropic.com"
+
+#: Default IMDS API version.
+_DEFAULT_IMDS_API_VERSION: str = "2018-02-01"
+
+
+class EntraManagedIdentityProvider(CallableTokenProvider):
+    """Entra managed-identity provider backed by the Azure IMDS endpoint.
+
+    Args:
+        client_id: Optional client ID of a user-assigned managed
+            identity. Omit for the resource's system-assigned identity.
+        resource: The resource (audience) to request. Defaults to
+            ``https://api.anthropic.com``.
+        api_version: IMDS API version. Defaults to ``2018-02-01``.
+        imds_endpoint: Override for the IMDS URL — primarily for tests.
+        request_timeout: Seconds to wait for the IMDS response.
+            Defaults to five seconds; IMDS is link-local and fast.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str | None = None,
+        resource: str = _DEFAULT_RESOURCE,
+        api_version: str = _DEFAULT_IMDS_API_VERSION,
+        imds_endpoint: str = _IMDS_TOKEN_ENDPOINT,
+        request_timeout: float = 5.0,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        self._client_id: str | None = client_id
+        self._resource: str = resource
+        self._api_version: str = api_version
+        self._imds_endpoint: str = imds_endpoint
+        self._request_timeout: float = request_timeout
+        super().__init__(
+            token_fn=self._fetch_imds_id_token,
+            provider_label="entra-imds",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+    def _fetch_imds_id_token(self) -> str:
+        """Fetch the OIDC ``id_token`` from the Azure IMDS endpoint.
+
+        Raises a precise :class:`TokenAcquisitionError` on every failure
+        mode; the base :class:`CallableTokenProvider` passes typed
+        errors through unchanged.
+        """
+        params: dict[str, str] = {
+            "api-version": self._api_version,
+            "resource": self._resource,
+        }
+        if self._client_id is not None:
+            params["client_id"] = self._client_id
+
+        try:
+            response = httpx.get(
+                self._imds_endpoint,
+                params=params,
+                headers={"Metadata": "true"},
+                timeout=self._request_timeout,
+            )
+        except httpx.TimeoutException as exc:
+            raise TokenAcquisitionError(
+                f"[entra-imds] the Azure Instance Metadata Service at "
+                f"{self._imds_endpoint} timed out after "
+                f"{self._request_timeout}s. Most common cause: this workload "
+                f"is not running on Azure compute, or egress to "
+                f"169.254.169.254 is blocked."
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise TokenAcquisitionError(
+                f"[entra-imds] could not reach the Azure Instance Metadata "
+                f"Service at {self._imds_endpoint} ({type(exc).__name__}). "
+                f"Most common cause: this workload is not running on Azure "
+                f"compute with a managed identity assigned. Underlying error: "
+                f"{exc}"
+            ) from exc
+
+        if response.status_code != 200:
+            raise TokenAcquisitionError(
+                f"[entra-imds] IMDS returned HTTP {response.status_code}. "
+                f"Most common cause: no managed identity is assigned to this "
+                f"resource, or the requested resource {self._resource!r} is "
+                f"not permitted. Response body: {response.text}"
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise TokenAcquisitionError(
+                f"[entra-imds] IMDS returned a non-JSON body. Body preview: "
+                f"{response.text[:200]!r}"
+            ) from exc
+
+        id_token = body.get("id_token")
+        if not isinstance(id_token, str) or not id_token:
+            raise TokenAcquisitionError(
+                f"[entra-imds] IMDS response did not contain an 'id_token' "
+                f"field. Most common cause: the managed identity returned "
+                f"only an access_token; the federation flow needs the OIDC "
+                f"id_token. Body keys: {list(body.keys())}"
+            )
+        return id_token
+
+
+class EntraProjectedTokenProvider(FileTokenProvider):
+    """Entra projected-token provider for AKS Workload Identity.
+
+    Args:
+        token_file: Path to the projected token. Defaults to the value
+            of ``$AZURE_FEDERATED_TOKEN_FILE`` or, if that is unset,
+            :data:`DEFAULT_AZURE_FEDERATED_TOKEN_FILE`.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_file: str | Path | None = None,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        resolved_path: str | Path
+        if token_file is not None:
+            resolved_path = token_file
+        else:
+            resolved_path = os.environ.get(
+                ENV_AZURE_FEDERATED_TOKEN_FILE,
+                DEFAULT_AZURE_FEDERATED_TOKEN_FILE,
+            )
+        super().__init__(
+            token_file=resolved_path,
+            provider_label="entra-projected",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+
+def from_entra(
+    *,
+    mode: Literal["auto", "imds", "projected"] = "auto",
+    client_id: str | None = None,
+    token_file: str | Path | None = None,
+    resource: str = _DEFAULT_RESOURCE,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+    exchange_timeout: float = 10.0,
+) -> EntraManagedIdentityProvider | EntraProjectedTokenProvider:
+    """Build a Microsoft Entra ID identity provider.
+
+    Args:
+        mode: ``"auto"`` (default) picks projected when
+            ``AZURE_FEDERATED_TOKEN_FILE`` is set, otherwise IMDS.
+            Force a mode with ``"imds"`` or ``"projected"``.
+        client_id: Client ID of a user-assigned managed identity
+            (IMDS mode only).
+        token_file: Projected-token path (projected mode only).
+            Defaults to ``$AZURE_FEDERATED_TOKEN_FILE``.
+        resource: Resource/audience to request from IMDS (IMDS mode
+            only). Defaults to ``https://api.anthropic.com``.
+        federation_rule_id: The ``fdrl_*`` identifier. Falls back to
+            ``ANTHROPIC_FEDERATION_RULE_ID``.
+        organization_id: The organization UUID. Falls back to
+            ``ANTHROPIC_ORGANIZATION_ID``.
+        service_account_id: The ``svac_*`` identifier. Falls back to
+            ``ANTHROPIC_SERVICE_ACCOUNT_ID``.
+        workspace_id: Optional ``wrkspc_*`` identifier. Falls back to
+            ``ANTHROPIC_WORKSPACE_ID``.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+    Returns:
+        An :class:`EntraManagedIdentityProvider` for IMDS mode or an
+        :class:`EntraProjectedTokenProvider` for projected mode.
+
+    Raises:
+        ProviderConfigError: If ``mode`` is not one of ``auto``,
+            ``imds``, or ``projected``, or if a required federation
+            identifier is unset.
+    """
+    resolved_mode = mode
+    if resolved_mode == "auto":
+        resolved_mode = (
+            "projected"
+            if os.environ.get(ENV_AZURE_FEDERATED_TOKEN_FILE)
+            else "imds"
+        )
+
+    creds = _resolve_anthropic_credentials(
+        federation_rule_id=federation_rule_id,
+        organization_id=organization_id,
+        service_account_id=service_account_id,
+        workspace_id=workspace_id,
+    )
+    fed = cast(str, creds["federation_rule_id"])
+    org = cast(str, creds["organization_id"])
+    svc = cast(str, creds["service_account_id"])
+    ws = creds["workspace_id"]
+
+    if resolved_mode == "projected":
+        return EntraProjectedTokenProvider(
+            token_file=token_file,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    if resolved_mode == "imds":
+        return EntraManagedIdentityProvider(
+            client_id=client_id,
+            resource=resource,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    raise ProviderConfigError(
+        f"Unknown Entra mode {mode!r}. Valid modes are 'auto', 'imds', and "
+        f"'projected'."
+    )

--- a/src/promptise/identity/providers/gcp.py
+++ b/src/promptise/identity/providers/gcp.py
@@ -1,0 +1,203 @@
+"""Google Cloud identity provider.
+
+A single provider that reads an OIDC identity token from the Google
+Compute metadata server. Works on Compute Engine, GKE, Cloud Run,
+Cloud Functions, and any other GCP runtime exposing the metadata
+server at ``metadata.google.internal``.
+
+The metadata identity endpoint returns the JWT as a **plain string**
+in the response body — it is *not* a JSON wrapper (unlike Azure IMDS,
+which returns JSON with an ``id_token`` field). The audience is
+supplied as a query parameter. The response body must be used directly
+and never parsed as JSON.
+
+GCP needs no cloud SDK — the metadata server is a plain HTTP GET — so
+there is no optional dependency for this provider.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+
+from .._core.callable_provider import CallableTokenProvider
+from .._core.errors import TokenAcquisitionError
+from .._internal.env import _resolve_anthropic_credentials
+
+#: Template for the GCP metadata identity endpoint. The service-account
+#: email segment selects which attached service account issues the token.
+_METADATA_IDENTITY_URL_TEMPLATE: str = (
+    "http://metadata.google.internal/computeMetadata/v1/instance/"
+    "service-accounts/{service_account_email}/identity"
+)
+
+#: Default audience requested in the identity token.
+_DEFAULT_AUDIENCE: str = "https://api.anthropic.com"
+
+#: Default service account — the instance's primary attached account.
+_DEFAULT_SERVICE_ACCOUNT_EMAIL: str = "default"
+
+
+class GcpMetadataProvider(CallableTokenProvider):
+    """GCP identity provider backed by the Compute metadata server.
+
+    Args:
+        audience: Audience to request in the identity token. Defaults to
+            ``https://api.anthropic.com``.
+        service_account_email: The attached service account whose
+            identity to request. ``"default"`` (the default) selects the
+            instance's primary service account; pass a full email to
+            select a specific one.
+        metadata_endpoint: Override for the metadata URL — primarily for
+            tests. When ``None`` it is derived from
+            ``service_account_email``.
+        request_timeout: Seconds to wait for the metadata response.
+            Defaults to five seconds; the metadata server is link-local.
+        federation_rule_id: See :class:`IdentityProvider`. This is the
+            Anthropic ``fdrl_*`` identifier — distinct from
+            ``service_account_email``, which is the GCP service account.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`. The Anthropic
+            ``svac_*`` identifier — again distinct from the GCP
+            ``service_account_email``.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        audience: str = _DEFAULT_AUDIENCE,
+        service_account_email: str = _DEFAULT_SERVICE_ACCOUNT_EMAIL,
+        metadata_endpoint: str | None = None,
+        request_timeout: float = 5.0,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        self._audience: str = audience
+        self._service_account_email: str = service_account_email
+        self._metadata_endpoint: str = (
+            metadata_endpoint
+            if metadata_endpoint is not None
+            else _METADATA_IDENTITY_URL_TEMPLATE.format(
+                service_account_email=service_account_email
+            )
+        )
+        self._request_timeout: float = request_timeout
+        super().__init__(
+            token_fn=self._fetch_metadata_identity_token,
+            provider_label="gcp-metadata",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+    def _fetch_metadata_identity_token(self) -> str:
+        """Fetch the OIDC identity token from the GCP metadata server.
+
+        The response body is the JWT itself — returned verbatim, never
+        parsed as JSON. Raises a precise :class:`TokenAcquisitionError`
+        on every failure mode; the base passes typed errors through.
+        """
+        try:
+            response = httpx.get(
+                self._metadata_endpoint,
+                params={"audience": self._audience},
+                headers={"Metadata-Flavor": "Google"},
+                timeout=self._request_timeout,
+            )
+        except httpx.TimeoutException as exc:
+            raise TokenAcquisitionError(
+                f"[gcp-metadata] the Google Compute metadata server at "
+                f"{self._metadata_endpoint} timed out after "
+                f"{self._request_timeout}s. Most common cause: this workload "
+                f"is not running on Google Cloud, or egress to "
+                f"metadata.google.internal is blocked."
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise TokenAcquisitionError(
+                f"[gcp-metadata] could not reach the Google Compute metadata "
+                f"server at {self._metadata_endpoint} ({type(exc).__name__}). "
+                f"Most common cause: this workload is not running on Google "
+                f"Cloud compute. Underlying error: {exc}"
+            ) from exc
+
+        if response.status_code != 200:
+            raise TokenAcquisitionError(
+                f"[gcp-metadata] the metadata server returned HTTP "
+                f"{response.status_code}. Most common cause: the service "
+                f"account {self._service_account_email!r} is not attached to "
+                f"this instance, or the audience {self._audience!r} is not "
+                f"permitted. Response body: {response.text}"
+            )
+
+        # The identity endpoint returns the JWT directly as the body —
+        # plain text, not JSON. Use it verbatim.
+        token = response.text.strip()
+        if not token:
+            raise TokenAcquisitionError(
+                "[gcp-metadata] the metadata server returned an empty body. "
+                "Most common cause: a transient metadata-server issue or a "
+                "malformed audience parameter."
+            )
+        return token
+
+
+def from_gcp(
+    *,
+    audience: str = _DEFAULT_AUDIENCE,
+    service_account_email: str = _DEFAULT_SERVICE_ACCOUNT_EMAIL,
+    request_timeout: float = 5.0,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+    exchange_timeout: float = 10.0,
+) -> GcpMetadataProvider:
+    """Build a Google Cloud identity provider.
+
+    Args:
+        audience: Audience requested in the identity token. Defaults to
+            ``https://api.anthropic.com``.
+        service_account_email: The attached service account whose
+            identity to request. Defaults to ``"default"``.
+        request_timeout: Seconds to wait for the metadata response.
+        federation_rule_id: The ``fdrl_*`` identifier. Falls back to
+            ``ANTHROPIC_FEDERATION_RULE_ID``.
+        organization_id: The organization UUID. Falls back to
+            ``ANTHROPIC_ORGANIZATION_ID``.
+        service_account_id: The Anthropic ``svac_*`` identifier. Falls
+            back to ``ANTHROPIC_SERVICE_ACCOUNT_ID``. Distinct from
+            ``service_account_email``.
+        workspace_id: Optional ``wrkspc_*`` identifier. Falls back to
+            ``ANTHROPIC_WORKSPACE_ID``.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+    Returns:
+        A :class:`GcpMetadataProvider`.
+
+    Raises:
+        ProviderConfigError: If a required federation identifier is unset.
+    """
+    creds = _resolve_anthropic_credentials(
+        federation_rule_id=federation_rule_id,
+        organization_id=organization_id,
+        service_account_id=service_account_id,
+        workspace_id=workspace_id,
+    )
+    return GcpMetadataProvider(
+        audience=audience,
+        service_account_email=service_account_email,
+        request_timeout=request_timeout,
+        federation_rule_id=cast(str, creds["federation_rule_id"]),
+        organization_id=cast(str, creds["organization_id"]),
+        service_account_id=cast(str, creds["service_account_id"]),
+        workspace_id=creds["workspace_id"],
+        exchange_timeout=exchange_timeout,
+    )

--- a/src/promptise/identity/providers/oidc.py
+++ b/src/promptise/identity/providers/oidc.py
@@ -1,0 +1,256 @@
+"""Generic OIDC identity provider.
+
+For any standards-compliant OIDC issuer that Promptise does not ship a
+dedicated provider for — GitLab CI, CircleCI, Azure DevOps, Keycloak,
+Authentik, Dex, and others. The upstream JWT reaches the framework via
+exactly one of three mutually-exclusive sources:
+
+* a **file** on disk (``token_file``) — for systems that project the
+  OIDC token to a path;
+* a **callable** (``token_fn``) — for programmatic acquisition;
+* an **environment variable** (``token_env_var``) — the simplest path,
+  used by CI systems that expose the token directly in the environment.
+
+The cloud providers shipped in later phases (Entra, AWS, GCP, SPIFFE)
+all reduce to one of these two base mechanisms; this module is the
+foundation they build on.
+
+Example::
+
+    from promptise.identity.providers.oidc import from_oidc
+
+    # GitLab CI exposes its OIDC token in an environment variable.
+    provider = from_oidc(
+        issuer="https://gitlab.com",
+        token_env_var="CI_JOB_JWT_V2",
+        # federation IDs fall back to the ANTHROPIC_* env vars when
+        # omitted.
+    )
+    access_token = provider.get_token()
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+from .._core.callable_provider import CallableTokenProvider
+from .._core.errors import ProviderConfigError, TokenAcquisitionError
+from .._core.file_provider import FileTokenProvider
+from .._internal.env import _resolve_anthropic_credentials
+
+
+class OidcFileProvider(FileTokenProvider):
+    """Generic OIDC provider that reads the JWT from a file path.
+
+    A thin specialisation of :class:`FileTokenProvider` that records
+    the issuer and fixes the provider label to ``"oidc:<issuer>"``.
+    Construct via :func:`from_oidc` rather than directly.
+
+    Args:
+        issuer: The OIDC issuer URL — the ``iss`` claim your JWTs carry.
+            Recorded for diagnostics and embedded in the provider label.
+        token_file: See :class:`FileTokenProvider`.
+        federation_rule_id: See :class:`FileTokenProvider`.
+        organization_id: See :class:`FileTokenProvider`.
+        service_account_id: See :class:`FileTokenProvider`.
+        workspace_id: See :class:`FileTokenProvider`.
+        exchange_timeout: See :class:`FileTokenProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        token_file: str | Path,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            token_file=token_file,
+            provider_label=f"oidc:{issuer}",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+        self.issuer: str = issuer
+
+
+class OidcCallableProvider(CallableTokenProvider):
+    """Generic OIDC provider that invokes a callable for the JWT.
+
+    A thin specialisation of :class:`CallableTokenProvider` that records
+    the issuer and fixes the provider label to ``"oidc:<issuer>"``.
+    Construct via :func:`from_oidc` rather than directly. Environment-
+    variable mode is implemented on top of this class with a callable
+    that reads the variable fresh on every refresh.
+
+    Args:
+        issuer: The OIDC issuer URL — the ``iss`` claim your JWTs carry.
+        token_fn: See :class:`CallableTokenProvider`.
+        federation_rule_id: See :class:`CallableTokenProvider`.
+        organization_id: See :class:`CallableTokenProvider`.
+        service_account_id: See :class:`CallableTokenProvider`.
+        workspace_id: See :class:`CallableTokenProvider`.
+        exchange_timeout: See :class:`CallableTokenProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        token_fn: Callable[[], str],
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            token_fn=token_fn,
+            provider_label=f"oidc:{issuer}",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+        self.issuer: str = issuer
+
+
+def _make_env_var_reader(var_name: str) -> Callable[[], str]:
+    """Return a callable that reads the JWT from ``var_name`` each call.
+
+    The variable is read fresh on every refresh — some CI systems
+    rotate the projected OIDC token in place, just as Kubernetes
+    rotates projected files (build plan section 4.6).
+    """
+
+    def _read() -> str:
+        value = os.environ.get(var_name)
+        if value is None or not value.strip():
+            raise TokenAcquisitionError(
+                f"OIDC token environment variable {var_name!r} is not set "
+                f"(or is empty) at refresh time. Most common cause: the CI "
+                f"system that injects the OIDC token did not run for this "
+                f"job, or the variable name is misspelled."
+            )
+        return value
+
+    return _read
+
+
+def from_oidc(
+    issuer: str,
+    *,
+    token_file: str | Path | None = None,
+    token_fn: Callable[[], str] | None = None,
+    token_env_var: str | None = None,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+    exchange_timeout: float = 10.0,
+) -> OidcFileProvider | OidcCallableProvider:
+    """Build a generic OIDC identity provider.
+
+    Exactly one of ``token_file``, ``token_fn``, or ``token_env_var``
+    must be supplied — they are the three mutually-exclusive ways the
+    issuer's JWT reaches the framework.
+
+    Args:
+        issuer: The OIDC issuer URL (the ``iss`` claim your JWTs carry).
+            Used in the provider label and recorded for diagnostics.
+        token_file: Path to a file the issuer projects the JWT into.
+        token_fn: A zero-argument callable returning the JWT string.
+        token_env_var: Name of an environment variable holding the JWT.
+            Read fresh on every refresh.
+        federation_rule_id: The ``fdrl_*`` identifier. Falls back to
+            ``ANTHROPIC_FEDERATION_RULE_ID`` when omitted.
+        organization_id: The organization UUID. Falls back to
+            ``ANTHROPIC_ORGANIZATION_ID``.
+        service_account_id: The ``svac_*`` identifier. Falls back to
+            ``ANTHROPIC_SERVICE_ACCOUNT_ID``.
+        workspace_id: Optional ``wrkspc_*`` identifier. Falls back to
+            ``ANTHROPIC_WORKSPACE_ID``.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+    Returns:
+        An :class:`OidcFileProvider` for ``token_file`` mode, or an
+        :class:`OidcCallableProvider` for ``token_fn`` and
+        ``token_env_var`` modes.
+
+    Raises:
+        ProviderConfigError: If zero or more than one token source is
+            supplied, or if a required federation identifier is unset.
+    """
+    supplied = [
+        name
+        for name, value in (
+            ("token_file", token_file),
+            ("token_fn", token_fn),
+            ("token_env_var", token_env_var),
+        )
+        if value is not None
+    ]
+    if len(supplied) == 0:
+        raise ProviderConfigError(
+            "from_oidc requires exactly one token source but none was "
+            "supplied. Pass one of token_file=..., token_fn=..., or "
+            "token_env_var=.... Most common cause: the JWT source for your "
+            "CI system was not wired up — e.g. GitLab CI exposes the token "
+            "in CI_JOB_JWT_V2, so pass token_env_var='CI_JOB_JWT_V2'."
+        )
+    if len(supplied) > 1:
+        raise ProviderConfigError(
+            f"from_oidc requires exactly one token source but "
+            f"{len(supplied)} were supplied ({', '.join(supplied)}). These "
+            f"are mutually exclusive — choose the single way the issuer's "
+            f"JWT reaches this workload and remove the others."
+        )
+
+    creds = _resolve_anthropic_credentials(
+        federation_rule_id=federation_rule_id,
+        organization_id=organization_id,
+        service_account_id=service_account_id,
+        workspace_id=workspace_id,
+    )
+    # _resolve_anthropic_credentials raises ProviderConfigError if any
+    # of the three required identifiers is missing, so by this point
+    # they are guaranteed non-None. The cast documents that invariant
+    # for the type checker; workspace_id remains legitimately optional.
+    fed = cast(str, creds["federation_rule_id"])
+    org = cast(str, creds["organization_id"])
+    svc = cast(str, creds["service_account_id"])
+    ws = creds["workspace_id"]
+
+    if token_file is not None:
+        return OidcFileProvider(
+            issuer=issuer,
+            token_file=token_file,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+
+    resolved_fn = token_fn if token_fn is not None else _make_env_var_reader(
+        cast(str, token_env_var)
+    )
+    return OidcCallableProvider(
+        issuer=issuer,
+        token_fn=resolved_fn,
+        federation_rule_id=fed,
+        organization_id=org,
+        service_account_id=svc,
+        workspace_id=ws,
+        exchange_timeout=exchange_timeout,
+    )

--- a/src/promptise/identity/providers/spiffe.py
+++ b/src/promptise/identity/providers/spiffe.py
@@ -1,0 +1,285 @@
+"""SPIFFE / SPIRE identity provider.
+
+Two acquisition modes:
+
+* **File mode** — reads a JWT-SVID written to disk by ``spiffe-helper``.
+  A thin alias over :class:`FileTokenProvider`; needs no pyspiffe.
+* **SDK mode** — lazily imports :mod:`pyspiffe`, connects to the SPIRE
+  agent's Workload API Unix socket, and fetches a JWT-SVID for the
+  configured audience.
+
+pyspiffe is an *optional* dependency (``pip install
+promptise[identity-spiffe]``). The SDK provider imports it inside the
+acquisition method, never at module top, so a workload that uses
+``spiffe-helper`` file output — or a different cloud — does not need
+pyspiffe installed. When the import fails the provider raises
+:class:`ProviderConfigError` naming the exact install command.
+
+The pyspiffe Workload-API call is coded against the documented
+``pyspiffe>=1.0`` surface (``WorkloadApiClient.fetch_jwt_svid``). The
+serialized-token accessor and client teardown are handled defensively
+because their exact form has varied across pyspiffe releases.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from .._core.callable_provider import CallableTokenProvider
+from .._core.errors import ProviderConfigError, TokenAcquisitionError
+from .._core.file_provider import FileTokenProvider
+from .._internal.env import _resolve_anthropic_credentials
+
+#: Environment variable naming the SPIRE agent Workload API socket.
+ENV_SPIFFE_ENDPOINT_SOCKET: str = "SPIFFE_ENDPOINT_SOCKET"
+
+#: Default Workload API socket path used when the env var is unset.
+DEFAULT_SPIFFE_ENDPOINT_SOCKET: str = "unix:///tmp/spire-agent/public/api.sock"
+
+#: Default audience requested in the JWT-SVID.
+_DEFAULT_AUDIENCE: str = "https://api.anthropic.com"
+
+#: The exact install command surfaced when pyspiffe is missing.
+_INSTALL_HINT: str = "pip install promptise[identity-spiffe]"
+
+
+class SpiffeFileProvider(FileTokenProvider):
+    """SPIFFE provider reading a JWT-SVID written by ``spiffe-helper``.
+
+    Args:
+        token_file: Path to the JWT-SVID file ``spiffe-helper`` rotates.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_file: str | Path,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            token_file=token_file,
+            provider_label="spiffe-file",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+
+class SpiffeSdkProvider(CallableTokenProvider):
+    """SPIFFE provider using the Workload API via pyspiffe (lazy import).
+
+    Args:
+        socket_path: SPIRE agent Workload API socket. Falls back to
+            ``$SPIFFE_ENDPOINT_SOCKET`` and then
+            :data:`DEFAULT_SPIFFE_ENDPOINT_SOCKET`.
+        audience: Audience to request in the JWT-SVID. Defaults to
+            ``https://api.anthropic.com``.
+        federation_rule_id: See :class:`IdentityProvider`.
+        organization_id: See :class:`IdentityProvider`.
+        service_account_id: See :class:`IdentityProvider`.
+        workspace_id: See :class:`IdentityProvider`.
+        exchange_timeout: See :class:`IdentityProvider`.
+    """
+
+    def __init__(
+        self,
+        *,
+        socket_path: str | None = None,
+        audience: str = _DEFAULT_AUDIENCE,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        exchange_timeout: float = 10.0,
+    ) -> None:
+        self._socket_path: str = (
+            socket_path
+            or os.environ.get(ENV_SPIFFE_ENDPOINT_SOCKET)
+            or DEFAULT_SPIFFE_ENDPOINT_SOCKET
+        )
+        self._audience: str = audience
+        super().__init__(
+            token_fn=self._fetch_jwt_svid,
+            provider_label="spiffe-sdk",
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+            exchange_timeout=exchange_timeout,
+        )
+
+    def _fetch_jwt_svid(self) -> str:
+        """Fetch a JWT-SVID from the SPIRE Workload API.
+
+        Lazily imports pyspiffe (principle 4.2). Raises
+        :class:`ProviderConfigError` when pyspiffe is missing and
+        :class:`TokenAcquisitionError` when the Workload API call
+        fails; both propagate through the base unchanged.
+        """
+        try:
+            from pyspiffe.workloadapi.workload_api_client import (  # noqa: E402
+                WorkloadApiClient,
+            )
+        except ImportError as exc:
+            raise ProviderConfigError(
+                f"[spiffe-sdk] SPIFFE SDK mode requires pyspiffe, which is "
+                f"not installed. Install it with: {_INSTALL_HINT}. "
+                f"Alternatively use file mode "
+                f"(from_spiffe(token_file=...)) with spiffe-helper, which "
+                f"needs no pyspiffe."
+            ) from exc
+
+        client = WorkloadApiClient(spiffe_socket_path=self._socket_path)
+        try:
+            jwt_svid = client.fetch_jwt_svid(audiences={self._audience})
+        except Exception as exc:
+            raise TokenAcquisitionError(
+                f"[spiffe-sdk] fetching a JWT-SVID from the Workload API at "
+                f"{self._socket_path} failed ({type(exc).__name__}: {exc}). "
+                f"Most common cause: no SPIRE agent is listening on that "
+                f"socket, or this workload has no registration entry."
+            ) from exc
+        finally:
+            _close_quietly(client)
+
+        return _extract_serialized_token(jwt_svid, socket_path=self._socket_path)
+
+
+def _close_quietly(client: Any) -> None:
+    """Best-effort close of a pyspiffe client.
+
+    The teardown method has varied across pyspiffe releases; close it
+    if a ``close`` callable exists and swallow any teardown error so it
+    does not mask the fetch result.
+    """
+    close = getattr(client, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001 — teardown failures must not mask success
+            pass
+
+
+def _extract_serialized_token(jwt_svid: Any, *, socket_path: str) -> str:
+    """Extract the serialized JWT string from a pyspiffe JwtSvid.
+
+    The serialized-token accessor differs across pyspiffe versions —
+    an attribute on some, a method on others. Try the documented forms
+    in order and raise a precise error if none yields a non-empty string.
+    """
+    for attr in ("token", "token_str", "marshal", "serialize"):
+        candidate = getattr(jwt_svid, attr, None)
+        if callable(candidate):
+            try:
+                candidate = candidate()
+            except Exception:  # noqa: BLE001 — try the next accessor
+                continue
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    raise TokenAcquisitionError(
+        f"[spiffe-sdk] the Workload API at {socket_path} returned a "
+        f"JwtSvid, but the serialized token could not be extracted from "
+        f"it. Most common cause: the installed pyspiffe version exposes "
+        f"the token under an unexpected accessor."
+    )
+
+
+def from_spiffe(
+    *,
+    mode: Literal["auto", "file", "sdk"] = "auto",
+    token_file: str | Path | None = None,
+    socket_path: str | None = None,
+    audience: str = _DEFAULT_AUDIENCE,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+    exchange_timeout: float = 10.0,
+) -> SpiffeFileProvider | SpiffeSdkProvider:
+    """Build a SPIFFE / SPIRE identity provider.
+
+    Args:
+        mode: ``"auto"`` (default) picks file mode when ``token_file``
+            is supplied, otherwise SDK mode. Force a mode with
+            ``"file"`` or ``"sdk"``.
+        token_file: Path to a JWT-SVID file (file mode). Required for
+            file mode.
+        socket_path: SPIRE Workload API socket (SDK mode). Falls back to
+            ``$SPIFFE_ENDPOINT_SOCKET`` and then the default socket.
+        audience: Audience for the JWT-SVID (SDK mode).
+        federation_rule_id: The ``fdrl_*`` identifier. Falls back to
+            ``ANTHROPIC_FEDERATION_RULE_ID``.
+        organization_id: The organization UUID. Falls back to
+            ``ANTHROPIC_ORGANIZATION_ID``.
+        service_account_id: The ``svac_*`` identifier. Falls back to
+            ``ANTHROPIC_SERVICE_ACCOUNT_ID``.
+        workspace_id: Optional ``wrkspc_*`` identifier. Falls back to
+            ``ANTHROPIC_WORKSPACE_ID``.
+        exchange_timeout: Seconds to wait for the Anthropic exchange.
+
+    Returns:
+        A :class:`SpiffeFileProvider` for file mode or a
+        :class:`SpiffeSdkProvider` for SDK mode.
+
+    Raises:
+        ProviderConfigError: If ``mode`` is not ``auto``/``file``/``sdk``,
+            if file mode is selected without ``token_file``, or if a
+            required federation identifier is unset.
+    """
+    resolved_mode = mode
+    if resolved_mode == "auto":
+        resolved_mode = "file" if token_file is not None else "sdk"
+
+    creds = _resolve_anthropic_credentials(
+        federation_rule_id=federation_rule_id,
+        organization_id=organization_id,
+        service_account_id=service_account_id,
+        workspace_id=workspace_id,
+    )
+    fed = cast(str, creds["federation_rule_id"])
+    org = cast(str, creds["organization_id"])
+    svc = cast(str, creds["service_account_id"])
+    ws = creds["workspace_id"]
+
+    if resolved_mode == "file":
+        if token_file is None:
+            raise ProviderConfigError(
+                "from_spiffe file mode requires token_file=... — the path "
+                "spiffe-helper writes the JWT-SVID to. Most common cause: "
+                "mode='file' was requested without supplying the path."
+            )
+        return SpiffeFileProvider(
+            token_file=token_file,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    if resolved_mode == "sdk":
+        return SpiffeSdkProvider(
+            socket_path=socket_path,
+            audience=audience,
+            federation_rule_id=fed,
+            organization_id=org,
+            service_account_id=svc,
+            workspace_id=ws,
+            exchange_timeout=exchange_timeout,
+        )
+    raise ProviderConfigError(
+        f"Unknown SPIFFE mode {mode!r}. Valid modes are 'auto', 'file', and "
+        f"'sdk'."
+    )

--- a/tests/identity/_core/test_cache.py
+++ b/tests/identity/_core/test_cache.py
@@ -1,0 +1,85 @@
+"""Unit tests for :class:`MintedToken` and the two-tier refresh windows."""
+
+from __future__ import annotations
+
+import time
+
+from promptise.identity import (
+    ADVISORY_REFRESH_BUFFER_SECONDS,
+    MANDATORY_REFRESH_BUFFER_SECONDS,
+    MintedToken,
+)
+
+
+def test_buffer_constants_match_build_plan() -> None:
+    """The two refresh buffers must match section 4.5 of the build plan exactly."""
+    assert ADVISORY_REFRESH_BUFFER_SECONDS == 120
+    assert MANDATORY_REFRESH_BUFFER_SECONDS == 30
+
+
+def _mint(expires_in: int) -> MintedToken:
+    """Create a token whose nominal expiry is ``expires_in`` seconds from now.
+
+    The test JWT prefix here is the legitimate Anthropic format; this is
+    not a real credential — it is a literal made of the prefix plus the
+    word ``test``.
+    """
+    return MintedToken(
+        access_token="sk-ant-oat01-test",
+        token_type="Bearer",
+        expires_at_monotonic=time.monotonic() + expires_in,
+        expires_in_seconds=expires_in,
+    )
+
+
+def test_fresh_token_needs_no_refresh() -> None:
+    token = _mint(expires_in=3600)
+    assert not token.needs_advisory_refresh()
+    assert not token.needs_mandatory_refresh()
+    assert token.time_until_expiry() > 3500
+
+
+def test_token_inside_advisory_window_only() -> None:
+    # 90 s remaining: inside the 120 s advisory window but outside the
+    # 30 s mandatory window.
+    token = _mint(expires_in=90)
+    assert token.needs_advisory_refresh()
+    assert not token.needs_mandatory_refresh()
+
+
+def test_token_inside_mandatory_window_triggers_both() -> None:
+    # 15 s remaining: inside both windows.
+    token = _mint(expires_in=15)
+    assert token.needs_advisory_refresh()
+    assert token.needs_mandatory_refresh()
+
+
+def test_expired_token_triggers_both_windows() -> None:
+    token = _mint(expires_in=-1)
+    assert token.needs_advisory_refresh()
+    assert token.needs_mandatory_refresh()
+    assert token.time_until_expiry() < 0
+
+
+def test_time_until_expiry_uses_monotonic_clock() -> None:
+    """Section 4.5: wall-clock skew must not affect token validity.
+
+    Asserts the clock used is monotonic by observing that consecutive
+    calls always show a strictly decreasing remaining lifetime.
+    """
+    token = _mint(expires_in=600)
+    remaining_before = token.time_until_expiry()
+    time.sleep(0.05)
+    remaining_after = token.time_until_expiry()
+    assert remaining_before > remaining_after
+    assert remaining_after > 0
+
+
+def test_minted_token_is_frozen() -> None:
+    """Tokens are immutable — refresh replaces, never mutates."""
+    token = _mint(expires_in=3600)
+    try:
+        token.access_token = "tampered"  # type: ignore[misc]
+    except (AttributeError, Exception):  # noqa: BLE001 — covers both FrozenInstanceError and AttributeError
+        return
+    raise AssertionError("MintedToken should be frozen but allowed mutation")

--- a/tests/identity/_core/test_callable_provider.py
+++ b/tests/identity/_core/test_callable_provider.py
@@ -51,6 +51,23 @@ def test_callable_exception_is_wrapped_with_cause() -> None:
     assert isinstance(exc_info.value.__cause__, _Boom)
 
 
+def test_callable_raising_token_acquisition_error_is_not_double_wrapped() -> None:
+    """A callable that already raises a precise TokenAcquisitionError
+    (e.g. a metadata-service provider) should have it propagate
+    unchanged, not wrapped in a second generic one."""
+    sentinel = TokenAcquisitionError("[entra-imds] precise diagnostic message")
+
+    def fn() -> str:
+        raise sentinel
+
+    provider = _make_provider(fn)
+    with pytest.raises(TokenAcquisitionError) as exc_info:
+        provider._acquire_upstream_jwt()
+    # The exact same exception object propagates — no re-wrapping.
+    assert exc_info.value is sentinel
+    assert "upstream JWT callable raised" not in str(exc_info.value)
+
+
 def test_callable_returning_non_string_raises() -> None:
     def bad() -> Any:
         return 12345

--- a/tests/identity/_core/test_callable_provider.py
+++ b/tests/identity/_core/test_callable_provider.py
@@ -1,0 +1,233 @@
+"""Unit tests for :class:`CallableTokenProvider`.
+
+Covers success, exception wrapping, type validation, empty-result
+handling, and the cross-thread concurrency contract from section 4.4
+of the build plan.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import CallableTokenProvider, TokenAcquisitionError
+
+
+def _make_provider(token_fn: Callable[[], str]) -> CallableTokenProvider:
+    return CallableTokenProvider(
+        token_fn=token_fn,
+        provider_label="test-callable",
+        federation_rule_id="fdrl_test",
+        organization_id="org_test",
+        service_account_id="svac_test",
+    )
+
+
+def test_returns_value_from_callable() -> None:
+    provider = _make_provider(lambda: "header.payload.sig")
+    assert provider._acquire_upstream_jwt() == "header.payload.sig"
+
+
+def test_strips_whitespace_around_callable_result() -> None:
+    provider = _make_provider(lambda: "  header.payload.sig\n")
+    assert provider._acquire_upstream_jwt() == "header.payload.sig"
+
+
+def test_callable_exception_is_wrapped_with_cause() -> None:
+    class _Boom(Exception):
+        """Synthetic upstream failure."""
+
+    def fn() -> str:
+        raise _Boom("simulated metadata service failure")
+
+    provider = _make_provider(fn)
+    with pytest.raises(TokenAcquisitionError, match="_Boom") as exc_info:
+        provider._acquire_upstream_jwt()
+    assert isinstance(exc_info.value.__cause__, _Boom)
+
+
+def test_callable_returning_non_string_raises() -> None:
+    def bad() -> Any:
+        return 12345
+
+    provider = _make_provider(bad)
+    with pytest.raises(TokenAcquisitionError, match="expected str"):
+        provider._acquire_upstream_jwt()
+
+
+def test_callable_returning_empty_string_raises() -> None:
+    provider = _make_provider(lambda: "   \n")
+    with pytest.raises(TokenAcquisitionError, match="empty"):
+        provider._acquire_upstream_jwt()
+
+
+def test_provider_name_returns_label() -> None:
+    provider = _make_provider(lambda: "x.y.z")
+    assert provider.provider_name == "test-callable"
+
+
+def test_concurrent_get_token_calls_collapse_to_one_exchange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Section 4.4: a single :class:`IdentityProvider` shared across
+    threads must serialise concurrent ``get_token`` calls so the
+    upstream IdP is hit exactly once."""
+
+    upstream_call_count = [0]
+    exchange_call_count = [0]
+
+    def upstream() -> str:
+        upstream_call_count[0] += 1
+        # Sleep so the second thread enters the critical section
+        # while the first thread is still inside it.
+        time.sleep(0.05)
+        return "header.payload.sig"
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        exchange_call_count[0] += 1
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(transport_handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+    provider = _make_provider(upstream)
+    tokens: list[str] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            tokens.append(provider.get_token())
+        except BaseException as exc:  # noqa: BLE001 — capture and re-raise from main
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"workers raised: {errors!r}"
+    assert len(set(tokens)) == 1, "all five threads must receive the same token"
+    assert upstream_call_count[0] == 1, "upstream IdP must be hit exactly once"
+    assert exchange_call_count[0] == 1, "Anthropic exchange must be hit exactly once"
+
+
+def test_get_auth_header_returns_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_auth_header() is the shortcut for downstream HTTP calls."""
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(transport_handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+    provider = _make_provider(lambda: "header.payload.sig")
+    header = provider.get_auth_header()
+    assert header == {"Authorization": "Bearer sk-ant-oat01-mock"}
+
+
+def test_advisory_refresh_success_replaces_cached_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Section 4.5: when a token is inside the advisory window and the
+    refresh succeeds, the new token replaces the cached one."""
+
+    upstream_calls = [0]
+    expires_values = [90, 3600]  # first token already in advisory window
+
+    def upstream() -> str:
+        upstream_calls[0] += 1
+        return f"jwt.{upstream_calls[0]}.sig"
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        idx = min(upstream_calls[0] - 1, len(expires_values) - 1)
+        return httpx.Response(
+            200,
+            json={
+                "access_token": f"sk-ant-oat01-call{upstream_calls[0]}",
+                "expires_in": expires_values[idx],
+            },
+        )
+
+    transport = httpx.MockTransport(transport_handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+    provider = _make_provider(upstream)
+    first = provider.get_token()
+    assert first == "sk-ant-oat01-call1"
+    # First token is inside the advisory window (90 s); the next call
+    # triggers a successful refresh that returns a fresh, longer-lived
+    # token.
+    second = provider.get_token()
+    assert second == "sk-ant-oat01-call2"
+    assert upstream_calls[0] == 2
+
+
+def test_advisory_refresh_failure_keeps_cached_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Section 4.5: if the advisory refresh fails, the cached token
+    continues to be served and a warning is logged."""
+
+    upstream_calls = [0]
+    transport_calls = [0]
+
+    def upstream() -> str:
+        upstream_calls[0] += 1
+        if upstream_calls[0] == 1:
+            return "first.jwt.value"
+        raise RuntimeError("simulated upstream failure on refresh")
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        transport_calls[0] += 1
+        # First call returns a token already inside the advisory
+        # window (90 s remaining < 120 s advisory buffer).
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-first", "expires_in": 90},
+        )
+
+    transport = httpx.MockTransport(transport_handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+    provider = _make_provider(upstream)
+    first = provider.get_token()
+    assert first == "sk-ant-oat01-first"
+
+    # Second call: the cached token is inside the advisory window, so
+    # the provider attempts a refresh. The upstream callable raises.
+    # The cached token must still be returned and no exception leaks.
+    second = provider.get_token()
+    assert second == "sk-ant-oat01-first"
+    assert upstream_calls[0] == 2, "upstream was called for the refresh attempt"

--- a/tests/identity/_core/test_env.py
+++ b/tests/identity/_core/test_env.py
@@ -1,0 +1,90 @@
+"""Unit tests for the federation-credential environment helpers.
+
+``_internal/env.py`` is a Phase 1 deliverable, so it ships with its
+own tests per the build plan's "tests are not optional" principle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from promptise.identity import ProviderConfigError
+from promptise.identity._internal import env as env_mod
+
+
+def test_require_env_returns_stripped_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOME_VAR", "  value  ")
+    assert env_mod._require_env("SOME_VAR") == "value"
+
+
+def test_require_env_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ABSENT_VAR", raising=False)
+    with pytest.raises(ProviderConfigError, match="ABSENT_VAR is not set"):
+        env_mod._require_env("ABSENT_VAR")
+
+
+def test_require_env_whitespace_only_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLANK_VAR", "   ")
+    with pytest.raises(ProviderConfigError, match="BLANK_VAR is not set"):
+        env_mod._require_env("BLANK_VAR")
+
+
+def test_resolve_uses_overrides_when_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even with env vars set, explicit overrides win.
+    monkeypatch.setenv(env_mod.ENV_FEDERATION_RULE_ID, "fdrl_env")
+    monkeypatch.setenv(env_mod.ENV_ORGANIZATION_ID, "org_env")
+    monkeypatch.setenv(env_mod.ENV_SERVICE_ACCOUNT_ID, "svac_env")
+    creds = env_mod._resolve_anthropic_credentials(
+        federation_rule_id="fdrl_override",
+        organization_id="org_override",
+        service_account_id="svac_override",
+        workspace_id="wrkspc_override",
+    )
+    assert creds == {
+        "federation_rule_id": "fdrl_override",
+        "organization_id": "org_override",
+        "service_account_id": "svac_override",
+        "workspace_id": "wrkspc_override",
+    }
+
+
+def test_resolve_reads_env_when_no_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(env_mod.ENV_FEDERATION_RULE_ID, "fdrl_env")
+    monkeypatch.setenv(env_mod.ENV_ORGANIZATION_ID, "org_env")
+    monkeypatch.setenv(env_mod.ENV_SERVICE_ACCOUNT_ID, "svac_env")
+    monkeypatch.delenv(env_mod.ENV_WORKSPACE_ID, raising=False)
+    creds = env_mod._resolve_anthropic_credentials()
+    assert creds == {
+        "federation_rule_id": "fdrl_env",
+        "organization_id": "org_env",
+        "service_account_id": "svac_env",
+        "workspace_id": None,
+    }
+
+
+def test_resolve_reads_workspace_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(env_mod.ENV_FEDERATION_RULE_ID, "fdrl_env")
+    monkeypatch.setenv(env_mod.ENV_ORGANIZATION_ID, "org_env")
+    monkeypatch.setenv(env_mod.ENV_SERVICE_ACCOUNT_ID, "svac_env")
+    monkeypatch.setenv(env_mod.ENV_WORKSPACE_ID, "wrkspc_env")
+    creds = env_mod._resolve_anthropic_credentials()
+    assert creds["workspace_id"] == "wrkspc_env"
+
+
+def test_resolve_missing_required_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(env_mod.ENV_FEDERATION_RULE_ID, raising=False)
+    monkeypatch.setenv(env_mod.ENV_ORGANIZATION_ID, "org_env")
+    monkeypatch.setenv(env_mod.ENV_SERVICE_ACCOUNT_ID, "svac_env")
+    with pytest.raises(ProviderConfigError, match=env_mod.ENV_FEDERATION_RULE_ID):
+        env_mod._resolve_anthropic_credentials()
+
+
+def test_resolve_blank_workspace_env_treated_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_mod.ENV_FEDERATION_RULE_ID, "fdrl_env")
+    monkeypatch.setenv(env_mod.ENV_ORGANIZATION_ID, "org_env")
+    monkeypatch.setenv(env_mod.ENV_SERVICE_ACCOUNT_ID, "svac_env")
+    monkeypatch.setenv(env_mod.ENV_WORKSPACE_ID, "   ")
+    creds = env_mod._resolve_anthropic_credentials()
+    assert creds["workspace_id"] is None

--- a/tests/identity/_core/test_exchange.py
+++ b/tests/identity/_core/test_exchange.py
@@ -1,0 +1,327 @@
+"""Unit tests for the RFC 7523 JWT-bearer exchange.
+
+Mocks :func:`httpx.post` with an :class:`httpx.MockTransport` so the
+tests run with no network access and no real credentials. Every
+fixture below produces synthetic data — the ``access_token`` returned
+by the mock always starts with ``sk-ant-oat01-`` followed by literal
+text like ``mock`` so it is unmistakeable as a non-credential.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    MintedToken,
+    TokenAcquisitionError,
+    TokenExchangeError,
+)
+from promptise.identity._core import exchange as exchange_mod
+
+# Synthetic JWT — three dot-separated literals so it lexes as JWT-shaped
+# but contains nothing exchangeable. The signature is the literal word
+# 'sig', not a real signature.
+FAKE_JWT: str = "header.payload.sig"
+
+
+def _install_mock_post(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> list[httpx.Request]:
+    """Replace :func:`httpx.post` with one that uses ``handler``.
+
+    Returns a list of every request the handler observed so tests can
+    assert on payload contents.
+    """
+    captured: list[httpx.Request] = []
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(wrapped)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+    return captured
+
+
+def test_payload_matches_rfc_7523_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "sk-ant-oat01-mock",
+                "expires_in": 1800,
+                "token_type": "Bearer",
+            },
+        )
+
+    captured = _install_mock_post(monkeypatch, handler)
+
+    minted = exchange_mod.exchange_jwt_for_anthropic_token(
+        FAKE_JWT,
+        federation_rule_id="fdrl_test",
+        organization_id="org_test",
+        service_account_id="svac_test",
+        workspace_id=None,
+        provider_name="unit",
+    )
+
+    assert len(captured) == 1
+    request = captured[0]
+    assert str(request.url) == "https://api.anthropic.com/v1/oauth/token"
+    body = json.loads(request.content)
+    assert body["grant_type"] == "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    assert body["assertion"] == FAKE_JWT
+    assert body["federation_rule_id"] == "fdrl_test"
+    assert body["organization_id"] == "org_test"
+    assert body["service_account_id"] == "svac_test"
+    # workspace_id omitted from payload, not sent as null.
+    assert "workspace_id" not in body
+
+    assert isinstance(minted, MintedToken)
+    assert minted.access_token == "sk-ant-oat01-mock"
+    assert minted.expires_in_seconds == 1800
+    assert minted.token_type == "Bearer"
+
+
+def test_workspace_id_included_when_supplied(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    captured = _install_mock_post(monkeypatch, handler)
+    exchange_mod.exchange_jwt_for_anthropic_token(
+        FAKE_JWT,
+        federation_rule_id="fdrl_test",
+        organization_id="org_test",
+        service_account_id="svac_test",
+        workspace_id="wrkspc_test",
+        provider_name="unit",
+    )
+    body = json.loads(captured[0].content)
+    assert body["workspace_id"] == "wrkspc_test"
+
+
+def test_http_400_raises_token_exchange_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="invalid issuer claim")
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenExchangeError, match="HTTP 400"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_missing_access_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"expires_in": 3600})
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenExchangeError, match="missing the 'access_token'"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_wrong_access_token_prefix_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # An access-token-shaped string with the wrong prefix; this
+        # would indicate Anthropic changed the protocol.
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-api03-wrongkind", "expires_in": 3600},
+        )
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenExchangeError, match="does not start with"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_non_integer_expires_in_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": "not-a-number"},
+        )
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenExchangeError, match="'expires_in' is not an integer"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_non_json_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # HTTP 200 but the body is not JSON — e.g. an upstream proxy
+        # returned an HTML error page with a 200 status.
+        return httpx.Response(200, text="<html>not json</html>")
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenExchangeError, match="non-JSON body"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_scope_in_response_is_logged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When Anthropic returns a ``scope`` field it is included in the
+    INFO log line (section 4.3)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "sk-ant-oat01-mock",
+                "expires_in": 1800,
+                "scope": "messages:write",
+            },
+        )
+
+    _install_mock_post(monkeypatch, handler)
+    with caplog.at_level("INFO", logger="promptise.identity"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+    rendered = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "INFO")
+    assert "scope=messages:write" in rendered
+
+
+def test_timeout_raises_token_acquisition_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("simulated", request=request)
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenAcquisitionError, match="timed out"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_transport_error_raises_token_acquisition_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated DNS failure", request=request)
+
+    _install_mock_post(monkeypatch, handler)
+    with pytest.raises(TokenAcquisitionError, match="before a response was received"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+
+
+def test_minted_token_expiry_anchored_to_request_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``expires_at_monotonic`` must be derived from a snapshot taken
+    **before** the POST, so the cache treats the token as expiring
+    slightly earlier than its nominal lifetime."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 600},
+        )
+
+    _install_mock_post(monkeypatch, handler)
+    before = time.monotonic()
+    minted = exchange_mod.exchange_jwt_for_anthropic_token(
+        FAKE_JWT,
+        federation_rule_id="fdrl_test",
+        organization_id="org_test",
+        service_account_id="svac_test",
+        workspace_id=None,
+        provider_name="unit",
+    )
+    after = time.monotonic()
+    assert before + 600 <= minted.expires_at_monotonic <= after + 600 + 0.5
+
+
+def test_successful_exchange_logs_at_info(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Section 4.3 / 9.1: every successful exchange logs at INFO with
+    provider name and expires_in, but never with the access token."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock-secret", "expires_in": 1800},
+        )
+
+    _install_mock_post(monkeypatch, handler)
+    with caplog.at_level("INFO", logger="promptise.identity"):
+        exchange_mod.exchange_jwt_for_anthropic_token(
+            FAKE_JWT,
+            federation_rule_id="fdrl_test",
+            organization_id="org_test",
+            service_account_id="svac_test",
+            workspace_id=None,
+            provider_name="unit",
+        )
+    # Find the success log line.
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) >= 1
+    rendered = "\n".join(r.getMessage() for r in info_records)
+    assert "provider=unit" in rendered
+    assert "expires_in=1800" in rendered
+    # Critical: the access token MUST NOT appear in any log message
+    # (section 9.1). This is a security regression test.
+    for record in caplog.records:
+        assert "sk-ant-oat01-mock-secret" not in record.getMessage()
+        assert "header.payload.sig" not in record.getMessage()

--- a/tests/identity/_core/test_file_provider.py
+++ b/tests/identity/_core/test_file_provider.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`FileTokenProvider`.
+
+Covers the file-reading contract: strip trailing whitespace, raise on
+missing or empty files, and — critically — re-read on every refresh
+so projected-token rotation works (build plan section 4.6).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from promptise.identity import FileTokenProvider, TokenAcquisitionError
+
+
+def _make_provider(token_file: Path) -> FileTokenProvider:
+    """Construct a provider with synthetic federation IDs."""
+    return FileTokenProvider(
+        token_file=token_file,
+        provider_label="test-file",
+        federation_rule_id="fdrl_test",
+        organization_id="org_test",
+        service_account_id="svac_test",
+    )
+
+
+def test_reads_file_and_strips_whitespace(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text("header.payload.sig\n", encoding="utf-8")
+    provider = _make_provider(f)
+    assert provider._acquire_upstream_jwt() == "header.payload.sig"
+
+
+def test_missing_file_raises_with_path_in_message(tmp_path: Path) -> None:
+    f = tmp_path / "absent"
+    provider = _make_provider(f)
+    with pytest.raises(TokenAcquisitionError, match=str(f)):
+        provider._acquire_upstream_jwt()
+
+
+def test_empty_file_raises(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text("   \n", encoding="utf-8")
+    provider = _make_provider(f)
+    with pytest.raises(TokenAcquisitionError, match="empty"):
+        provider._acquire_upstream_jwt()
+
+
+def test_file_is_reread_every_call(tmp_path: Path) -> None:
+    """Section 4.6: the projection mechanism rewrites the file in
+    place. The provider must observe each new write, not cache the
+    first read."""
+    f = tmp_path / "token"
+    f.write_text("first.jwt.value", encoding="utf-8")
+    provider = _make_provider(f)
+    assert provider._acquire_upstream_jwt() == "first.jwt.value"
+
+    # Platform rewrites the file in place — simulate rotation.
+    f.write_text("second.jwt.value", encoding="utf-8")
+    assert provider._acquire_upstream_jwt() == "second.jwt.value"
+
+    f.write_text("third.jwt.value", encoding="utf-8")
+    assert provider._acquire_upstream_jwt() == "third.jwt.value"
+
+
+def test_token_file_property_exposes_path(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text("anything", encoding="utf-8")
+    provider = _make_provider(f)
+    assert provider.token_file == f
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission test")
+def test_unreadable_file_raises_permission_error(tmp_path: Path) -> None:
+    """If the file exists but the process cannot read it, the provider
+    raises :class:`TokenAcquisitionError` (not the bare OSError)."""
+    f = tmp_path / "token"
+    f.write_text("anything", encoding="utf-8")
+    # Strip every read permission. Running tests as root would bypass
+    # this; the CI environment is non-root.
+    f.chmod(stat.S_IWUSR)
+    provider = _make_provider(f)
+    try:
+        if os.geteuid() == 0:
+            pytest.skip("running as root; cannot test PermissionError")
+        with pytest.raises(TokenAcquisitionError, match="not readable"):
+            provider._acquire_upstream_jwt()
+    finally:
+        f.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_provider_name_returns_label(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text("x.y.z", encoding="utf-8")
+    provider = _make_provider(f)
+    assert provider.provider_name == "test-file"
+
+
+def test_path_pointing_at_directory_raises_token_acquisition_error(
+    tmp_path: Path,
+) -> None:
+    """A generic OSError (here IsADirectoryError, from pointing the
+    token path at a directory) is surfaced as TokenAcquisitionError,
+    not leaked as a bare OSError."""
+    directory = tmp_path / "a_directory"
+    directory.mkdir()
+    provider = _make_provider(directory)
+    with pytest.raises(TokenAcquisitionError, match="could not read projected token"):
+        provider._acquire_upstream_jwt()

--- a/tests/identity/_core/test_logging.py
+++ b/tests/identity/_core/test_logging.py
@@ -42,3 +42,30 @@ def test_configure_default_handler_is_idempotent() -> None:
             logger.removeHandler(h)
         for h in original:
             logger.addHandler(h)
+
+
+def test_configure_default_handler_skips_non_null_handlers() -> None:
+    """A non-NullHandler already on the logger must not short-circuit the
+    install — the loop skips past it and still adds exactly one NullHandler."""
+    logger = id_logging.logger
+    original = list(logger.handlers)
+    try:
+        # Clean slate with a single *non-null* handler present, so the
+        # idempotency loop iterates past a handler that is not a NullHandler.
+        for h in list(logger.handlers):
+            logger.removeHandler(h)
+        stream_handler = logging.StreamHandler()
+        logger.addHandler(stream_handler)
+
+        id_logging._configure_default_handler()
+
+        null_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.NullHandler)
+        ]
+        assert len(null_handlers) == 1
+        assert stream_handler in logger.handlers
+    finally:
+        for h in list(logger.handlers):
+            logger.removeHandler(h)
+        for h in original:
+            logger.addHandler(h)

--- a/tests/identity/_core/test_logging.py
+++ b/tests/identity/_core/test_logging.py
@@ -1,0 +1,44 @@
+"""Unit tests for the subsystem logger configuration."""
+
+from __future__ import annotations
+
+import logging
+
+from promptise.identity._internal import logging as id_logging
+
+
+def test_logger_name_is_subsystem_root() -> None:
+    assert id_logging.logger.name == "promptise.identity"
+
+
+def test_configure_default_handler_is_idempotent() -> None:
+    """Calling :func:`_configure_default_handler` repeatedly installs
+    exactly one NullHandler — never a duplicate."""
+    logger = id_logging.logger
+    # Snapshot and clear any existing NullHandlers so we exercise both
+    # the install branch and the early-return branch deterministically.
+    original = list(logger.handlers)
+    null_handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+    for h in null_handlers:
+        logger.removeHandler(h)
+    try:
+        # First call installs one.
+        id_logging._configure_default_handler()
+        after_first = [
+            h for h in logger.handlers if isinstance(h, logging.NullHandler)
+        ]
+        assert len(after_first) == 1
+
+        # Second call is a no-op — still exactly one.
+        id_logging._configure_default_handler()
+        after_second = [
+            h for h in logger.handlers if isinstance(h, logging.NullHandler)
+        ]
+        assert len(after_second) == 1
+    finally:
+        # Restore the original handler set so we don't leak state into
+        # other tests.
+        for h in list(logger.handlers):
+            logger.removeHandler(h)
+        for h in original:
+            logger.addHandler(h)

--- a/tests/identity/providers/test_aws.py
+++ b/tests/identity/providers/test_aws.py
@@ -1,0 +1,279 @@
+"""Unit tests for the AWS IAM provider and ``from_aws``.
+
+The STS happy path monkeypatches ``boto3.client`` to return a stub
+(boto3 is installed in the dev venv as the ``identity-aws`` extra).
+The missing-boto3 path injects ``None`` into ``sys.modules`` so the
+lazy ``import boto3`` raises ImportError — the technique the build
+plan specifies. The EKS-projected path uses a real temp file. No
+network access and no real credentials.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    AwsEksProjectedProvider,
+    AwsStsProvider,
+    ProviderConfigError,
+    TokenAcquisitionError,
+)
+from promptise.identity.providers.aws import (
+    ENV_ANTHROPIC_IDENTITY_TOKEN_FILE,
+    from_aws,
+)
+
+FAKE_JWT: str = "header.payload.sig"
+
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+class _FakeStsClient:
+    """Minimal stand-in for a boto3 STS client."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def get_web_identity_token(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self._response
+
+
+def _mock_boto3_client(
+    monkeypatch: pytest.MonkeyPatch, fake_client: _FakeStsClient
+) -> None:
+    import boto3
+
+    def _client(service_name: str, **kwargs: Any) -> _FakeStsClient:
+        assert service_name == "sts"
+        return fake_client
+
+    monkeypatch.setattr(boto3, "client", _client)
+
+
+def _mock_boto3_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Setting the module to None makes `import boto3` raise ImportError.
+    monkeypatch.setitem(sys.modules, "boto3", None)
+
+
+def _mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+def _clear_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
+# -- STS path -------------------------------------------------------------
+
+
+def test_sts_calls_get_web_identity_token_with_audience_and_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeStsClient({"WebIdentityToken": FAKE_JWT})
+    _mock_boto3_client(monkeypatch, fake)
+    provider = AwsStsProvider(region="us-east-1", **_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+    assert provider.provider_name == "aws-sts"
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["Audience"] == ["https://api.anthropic.com"]
+    assert call["SigningAlgorithm"] == "RS256"
+
+
+def test_sts_custom_audience_and_algorithm(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeStsClient({"WebIdentityToken": FAKE_JWT})
+    _mock_boto3_client(monkeypatch, fake)
+    provider = AwsStsProvider(
+        region="eu-west-1",
+        audience="https://custom.example.com",
+        signing_algorithm="ES256",
+        **_FED_KWARGS,
+    )
+    provider._acquire_upstream_jwt()
+    assert fake.calls[0]["Audience"] == ["https://custom.example.com"]
+    assert fake.calls[0]["SigningAlgorithm"] == "ES256"
+
+
+def test_sts_missing_web_identity_token_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeStsClient({"SomethingElse": "x"})
+    _mock_boto3_client(monkeypatch, fake)
+    provider = AwsStsProvider(region="us-east-1", **_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="did not contain a WebIdentityToken"):
+        provider._acquire_upstream_jwt()
+
+
+def test_sts_client_error_raises_token_acquisition_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import boto3
+
+    def _client(service_name: str, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated STS AccessDenied")
+
+    monkeypatch.setattr(boto3, "client", _client)
+    provider = AwsStsProvider(region="us-east-1", **_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="STS GetWebIdentityToken failed"):
+        provider._acquire_upstream_jwt()
+
+
+def test_sts_missing_boto3_raises_provider_config_error_with_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Build-plan phase-4 acceptance: the boto3-not-installed error names
+    the exact `pip install promptise[identity-aws]` command, and it
+    surfaces as ProviderConfigError (not wrapped in TokenAcquisitionError)."""
+    _mock_boto3_missing(monkeypatch)
+    provider = AwsStsProvider(region="us-east-1", **_FED_KWARGS)
+    with pytest.raises(ProviderConfigError) as exc_info:
+        provider._acquire_upstream_jwt()
+    assert "pip install promptise[identity-aws]" in str(exc_info.value)
+
+
+# -- Region resolution ----------------------------------------------------
+
+
+def test_region_from_explicit_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_region(monkeypatch)
+    provider = AwsStsProvider(region="ap-southeast-2", **_FED_KWARGS)
+    assert provider._region == "ap-southeast-2"
+
+
+def test_region_from_aws_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_region(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    provider = AwsStsProvider(**_FED_KWARGS)
+    assert provider._region == "us-west-2"
+
+
+def test_region_from_aws_default_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_region(monkeypatch)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+    provider = AwsStsProvider(**_FED_KWARGS)
+    assert provider._region == "us-east-2"
+
+
+def test_no_region_raises_at_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_region(monkeypatch)
+    with pytest.raises(ProviderConfigError, match="AWS STS is regional"):
+        AwsStsProvider(**_FED_KWARGS)
+
+
+# -- EKS projected path ---------------------------------------------------
+
+
+def test_eks_projected_reads_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    monkeypatch.setenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, str(f))
+    provider = AwsEksProjectedProvider(**_FED_KWARGS)
+    assert provider.token_file == f
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+    assert provider.provider_name == "aws-eks-projected"
+
+
+def test_eks_projected_explicit_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / "env"
+    env_file.write_text("env.jwt", encoding="utf-8")
+    explicit = tmp_path / "explicit"
+    explicit.write_text("explicit.jwt", encoding="utf-8")
+    monkeypatch.setenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, str(env_file))
+    provider = AwsEksProjectedProvider(token_file=explicit, **_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == "explicit.jwt"
+
+
+def test_eks_projected_default_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, raising=False)
+    provider = AwsEksProjectedProvider(**_FED_KWARGS)
+    assert str(provider.token_file).endswith("anthropic.com/token")
+
+
+# -- Factory --------------------------------------------------------------
+
+
+def test_from_aws_sts_mode_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeStsClient({"WebIdentityToken": FAKE_JWT})
+    _mock_boto3_client(monkeypatch, fake)
+    _mock_exchange(monkeypatch)
+    provider = from_aws(mode="sts", region="us-east-1", **_FED_KWARGS)
+    assert isinstance(provider, AwsStsProvider)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+def test_from_aws_projected_mode_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    _mock_exchange(monkeypatch)
+    provider = from_aws(mode="projected", token_file=f, **_FED_KWARGS)
+    assert isinstance(provider, AwsEksProjectedProvider)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+def test_from_aws_auto_picks_projected_when_token_file_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    monkeypatch.setenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, str(f))
+    provider = from_aws(mode="auto", **_FED_KWARGS)
+    assert isinstance(provider, AwsEksProjectedProvider)
+
+
+def test_from_aws_auto_picks_sts_when_token_file_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, raising=False)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    provider = from_aws(mode="auto", **_FED_KWARGS)
+    assert isinstance(provider, AwsStsProvider)
+
+
+def test_from_aws_unknown_mode_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="Unknown AWS mode"):
+        from_aws(mode="bogus", **_FED_KWARGS)  # type: ignore[arg-type]
+
+
+def test_from_aws_missing_federation_id_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Use projected mode so no region/boto3 is needed; the failure must
+    # be the missing federation ID.
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    monkeypatch.setenv(ENV_ANTHROPIC_IDENTITY_TOKEN_FILE, str(f))
+    monkeypatch.delenv("ANTHROPIC_FEDERATION_RULE_ID", raising=False)
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    with pytest.raises(ProviderConfigError, match="ANTHROPIC_FEDERATION_RULE_ID"):
+        from_aws(mode="projected")

--- a/tests/identity/providers/test_entra.py
+++ b/tests/identity/providers/test_entra.py
@@ -1,0 +1,258 @@
+"""Unit tests for the Microsoft Entra ID provider and ``from_entra``.
+
+Mocks the IMDS HTTP GET and the Anthropic exchange POST with
+:class:`httpx.MockTransport`. The projected-token path uses a real
+temporary file. No network access and no real credentials.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    EntraManagedIdentityProvider,
+    EntraProjectedTokenProvider,
+    ProviderConfigError,
+    TokenAcquisitionError,
+)
+from promptise.identity.providers.entra import (
+    ENV_AZURE_FEDERATED_TOKEN_FILE,
+    from_entra,
+)
+
+FAKE_JWT: str = "header.payload.sig"
+
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+def _mock_imds(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+) -> list[httpx.Request]:
+    """Replace httpx.get with a mock transport for the IMDS endpoint."""
+    captured: list[httpx.Request] = []
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(wrapped)
+
+    def mocked_get(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.get(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "get", mocked_get)
+    return captured
+
+
+def _mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace httpx.post so the Anthropic exchange returns a mock token."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+# -- IMDS path ------------------------------------------------------------
+
+
+def test_imds_extracts_id_token_and_sends_metadata_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # IMDS requires the Metadata: true header.
+        assert request.headers.get("Metadata") == "true"
+        assert "api-version" in request.url.params
+        assert request.url.params["resource"] == "https://api.anthropic.com"
+        return httpx.Response(200, json={"id_token": FAKE_JWT})
+
+    captured = _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+    assert len(captured) == 1
+    assert provider.provider_name == "entra-imds"
+
+
+def test_imds_client_id_added_when_user_assigned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["client_id"] == "00000000-1111-2222-3333-444444444444"
+        return httpx.Response(200, json={"id_token": FAKE_JWT})
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(
+        client_id="00000000-1111-2222-3333-444444444444",
+        **_FED_KWARGS,
+    )
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+def test_imds_unreachable_raises_token_acquisition_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host", request=request)
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="could not reach the Azure"):
+        provider._acquire_upstream_jwt()
+
+
+def test_imds_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("slow", request=request)
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="timed out"):
+        provider._acquire_upstream_jwt()
+
+
+def test_imds_non_200_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="no identity assigned")
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="HTTP 400"):
+        provider._acquire_upstream_jwt()
+
+
+def test_imds_non_json_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html>not json</html>")
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="non-JSON body"):
+        provider._acquire_upstream_jwt()
+
+
+def test_imds_response_without_id_token_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # IMDS returns an access_token but no id_token — the federation
+        # flow needs the id_token.
+        return httpx.Response(200, json={"access_token": "some-access-token"})
+
+    _mock_imds(monkeypatch, handler)
+    provider = EntraManagedIdentityProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="did not contain an 'id_token'"):
+        provider._acquire_upstream_jwt()
+
+
+# -- Projected-token path -------------------------------------------------
+
+
+def test_projected_reads_default_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "azure-identity-token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    monkeypatch.setenv(ENV_AZURE_FEDERATED_TOKEN_FILE, str(f))
+    provider = EntraProjectedTokenProvider(**_FED_KWARGS)
+    assert provider.token_file == f
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+    assert provider.provider_name == "entra-projected"
+
+
+def test_projected_explicit_token_file_overrides_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / "from-env"
+    env_file.write_text("env.jwt.value", encoding="utf-8")
+    explicit = tmp_path / "explicit"
+    explicit.write_text("explicit.jwt.value", encoding="utf-8")
+    monkeypatch.setenv(ENV_AZURE_FEDERATED_TOKEN_FILE, str(env_file))
+    provider = EntraProjectedTokenProvider(token_file=explicit, **_FED_KWARGS)
+    assert provider.token_file == explicit
+    assert provider._acquire_upstream_jwt() == "explicit.jwt.value"
+
+
+def test_projected_falls_back_to_default_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_AZURE_FEDERATED_TOKEN_FILE, raising=False)
+    provider = EntraProjectedTokenProvider(**_FED_KWARGS)
+    # The default path won't exist in the test environment; we only
+    # assert it was selected, not that it reads.
+    assert str(provider.token_file).endswith("azure-identity-token")
+
+
+# -- Factory + mode handling ----------------------------------------------
+
+
+def test_from_entra_imds_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    def imds_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id_token": FAKE_JWT})
+
+    _mock_imds(monkeypatch, imds_handler)
+    _mock_exchange(monkeypatch)
+    provider = from_entra(mode="imds", **_FED_KWARGS)
+    assert isinstance(provider, EntraManagedIdentityProvider)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+def test_from_entra_projected_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    _mock_exchange(monkeypatch)
+    provider = from_entra(mode="projected", token_file=f, **_FED_KWARGS)
+    assert isinstance(provider, EntraProjectedTokenProvider)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+def test_from_entra_auto_picks_projected_when_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    monkeypatch.setenv(ENV_AZURE_FEDERATED_TOKEN_FILE, str(f))
+    provider = from_entra(mode="auto", **_FED_KWARGS)
+    assert isinstance(provider, EntraProjectedTokenProvider)
+
+
+def test_from_entra_auto_picks_imds_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(ENV_AZURE_FEDERATED_TOKEN_FILE, raising=False)
+    provider = from_entra(mode="auto", **_FED_KWARGS)
+    assert isinstance(provider, EntraManagedIdentityProvider)
+
+
+def test_from_entra_unknown_mode_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="Unknown Entra mode"):
+        from_entra(mode="bogus", **_FED_KWARGS)  # type: ignore[arg-type]
+
+
+def test_from_entra_missing_federation_id_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_FEDERATION_RULE_ID", raising=False)
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    monkeypatch.delenv(ENV_AZURE_FEDERATED_TOKEN_FILE, raising=False)
+    with pytest.raises(ProviderConfigError, match="ANTHROPIC_FEDERATION_RULE_ID"):
+        from_entra(mode="imds")

--- a/tests/identity/providers/test_gcp.py
+++ b/tests/identity/providers/test_gcp.py
@@ -1,0 +1,211 @@
+"""Unit tests for the Google Cloud provider and ``from_gcp``.
+
+Mocks the metadata-server HTTP GET and the Anthropic exchange POST.
+A dedicated test proves the response body is used verbatim and never
+JSON-parsed (the key behaviour from section 5.9). No network access
+and no real credentials.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    GcpMetadataProvider,
+    ProviderConfigError,
+    TokenAcquisitionError,
+)
+from promptise.identity.providers.gcp import from_gcp
+
+FAKE_JWT: str = "header.payload.sig"
+
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+def _mock_metadata(
+    monkeypatch: pytest.MonkeyPatch, handler: Any
+) -> list[httpx.Request]:
+    captured: list[httpx.Request] = []
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(wrapped)
+
+    def mocked_get(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.get(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "get", mocked_get)
+    return captured
+
+
+def _mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+# -- Metadata path --------------------------------------------------------
+
+
+def test_sends_metadata_flavor_header_and_audience_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("Metadata-Flavor") == "Google"
+        assert request.url.params["audience"] == "https://api.anthropic.com"
+        assert "service-accounts/default/identity" in str(request.url)
+        return httpx.Response(200, text=FAKE_JWT)
+
+    captured = _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+    assert provider.provider_name == "gcp-metadata"
+    assert len(captured) == 1
+
+
+def test_body_returned_verbatim_not_json_parsed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Section 5.9: the metadata identity endpoint returns the JWT as a
+    plain string. The provider must use response.text directly and never
+    call .json(). Here the body is a bare JWT — if the code tried to
+    JSON-parse it the call would fail; instead it is returned verbatim."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="aaa.bbb.ccc")
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == "aaa.bbb.ccc"
+
+
+def test_body_whitespace_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=f"  {FAKE_JWT}\n")
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+def test_custom_service_account_email_changes_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "service-accounts/agent@project.iam.gserviceaccount.com/identity" in str(
+            request.url
+        )
+        return httpx.Response(200, text=FAKE_JWT)
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(
+        service_account_email="agent@project.iam.gserviceaccount.com",
+        **_FED_KWARGS,
+    )
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+def test_custom_audience(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["audience"] == "https://custom.example.com"
+        return httpx.Response(200, text=FAKE_JWT)
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(audience="https://custom.example.com", **_FED_KWARGS)
+    provider._acquire_upstream_jwt()
+
+
+def test_metadata_unreachable_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route", request=request)
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="could not reach the Google"):
+        provider._acquire_upstream_jwt()
+
+
+def test_metadata_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("slow", request=request)
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="timed out"):
+        provider._acquire_upstream_jwt()
+
+
+def test_metadata_non_200_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="service account not found")
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="HTTP 404"):
+        provider._acquire_upstream_jwt()
+
+
+def test_empty_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="   \n")
+
+    _mock_metadata(monkeypatch, handler)
+    provider = GcpMetadataProvider(**_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="empty body"):
+        provider._acquire_upstream_jwt()
+
+
+# -- Factory --------------------------------------------------------------
+
+
+def test_from_gcp_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    def metadata_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=FAKE_JWT)
+
+    _mock_metadata(monkeypatch, metadata_handler)
+    _mock_exchange(monkeypatch)
+    provider = from_gcp(**_FED_KWARGS)
+    assert isinstance(provider, GcpMetadataProvider)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+def test_from_gcp_passes_through_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = from_gcp(
+        audience="https://aud.example.com",
+        service_account_email="x@y.iam.gserviceaccount.com",
+        workspace_id="wrkspc_explicit",
+        **_FED_KWARGS,
+    )
+    assert provider._audience == "https://aud.example.com"
+    assert provider._service_account_email == "x@y.iam.gserviceaccount.com"
+    assert provider.workspace_id == "wrkspc_explicit"
+
+
+def test_from_gcp_missing_federation_id_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_FEDERATION_RULE_ID", raising=False)
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    with pytest.raises(ProviderConfigError, match="ANTHROPIC_FEDERATION_RULE_ID"):
+        from_gcp()

--- a/tests/identity/providers/test_oidc.py
+++ b/tests/identity/providers/test_oidc.py
@@ -1,0 +1,236 @@
+"""Unit tests for the generic OIDC provider and its ``from_oidc`` factory.
+
+Covers all three token sources (file, callable, env var), the
+mutual-exclusivity validation, issuer recording, federation-credential
+resolution, fresh env-var reads on rotation, and an end-to-end token
+acquisition through a mocked Anthropic exchange.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    OidcCallableProvider,
+    OidcFileProvider,
+    ProviderConfigError,
+    TokenAcquisitionError,
+)
+from promptise.identity.providers.oidc import from_oidc
+
+FAKE_JWT: str = "header.payload.sig"
+
+# Synthetic federation IDs reused across tests — identifiers, not
+# secrets (build plan section 4.1).
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+def _install_mock_exchange(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Mock the Anthropic exchange. Returns a counter dict the test can
+    assert on (``{"calls": N}``)."""
+    counter = {"calls": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter["calls"] += 1
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+    return counter
+
+
+# -- Source selection / validation ---------------------------------------
+
+
+def test_no_source_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="none was supplied"):
+        from_oidc(issuer="https://example.com", **_FED_KWARGS)
+
+
+def test_two_sources_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="2 were supplied"):
+        from_oidc(
+            issuer="https://example.com",
+            token_file="/tmp/a",
+            token_env_var="X",
+            **_FED_KWARGS,
+        )
+
+
+def test_three_sources_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="3 were supplied"):
+        from_oidc(
+            issuer="https://example.com",
+            token_file="/tmp/a",
+            token_fn=lambda: "x",
+            token_env_var="X",
+            **_FED_KWARGS,
+        )
+
+
+# -- File mode ------------------------------------------------------------
+
+
+def test_file_mode_returns_file_provider(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    provider = from_oidc(issuer="https://example.com", token_file=f, **_FED_KWARGS)
+    assert isinstance(provider, OidcFileProvider)
+    assert provider.issuer == "https://example.com"
+    assert provider.provider_name == "oidc:https://example.com"
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+# -- Callable mode --------------------------------------------------------
+
+
+def test_callable_mode_returns_callable_provider() -> None:
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_fn=lambda: FAKE_JWT,
+        **_FED_KWARGS,
+    )
+    assert isinstance(provider, OidcCallableProvider)
+    assert provider.issuer == "https://example.com"
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+# -- Env-var mode ---------------------------------------------------------
+
+
+def test_env_var_mode_returns_callable_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_OIDC_TOKEN", FAKE_JWT)
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_env_var="MY_OIDC_TOKEN",
+        **_FED_KWARGS,
+    )
+    assert isinstance(provider, OidcCallableProvider)
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+def test_env_var_mode_reads_fresh_each_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env-var mode must re-read the variable on every refresh so token
+    rotation in CI is observed (build plan section 4.6)."""
+    monkeypatch.setenv("MY_OIDC_TOKEN", "first.jwt.value")
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_env_var="MY_OIDC_TOKEN",
+        **_FED_KWARGS,
+    )
+    assert provider._acquire_upstream_jwt() == "first.jwt.value"
+    monkeypatch.setenv("MY_OIDC_TOKEN", "second.jwt.value")
+    assert provider._acquire_upstream_jwt() == "second.jwt.value"
+
+
+def test_env_var_unset_at_refresh_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_OIDC_TOKEN", FAKE_JWT)
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_env_var="MY_OIDC_TOKEN",
+        **_FED_KWARGS,
+    )
+    # The variable disappears between construction and refresh.
+    monkeypatch.delenv("MY_OIDC_TOKEN", raising=False)
+    with pytest.raises(TokenAcquisitionError, match="MY_OIDC_TOKEN"):
+        provider._acquire_upstream_jwt()
+
+
+# -- Federation-credential resolution ------------------------------------
+
+
+def test_federation_ids_resolved_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_FEDERATION_RULE_ID", "fdrl_env")
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    monkeypatch.delenv("ANTHROPIC_WORKSPACE_ID", raising=False)
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_fn=lambda: FAKE_JWT,
+    )
+    assert provider.federation_rule_id == "fdrl_env"
+    assert provider.organization_id == "org_env"
+    assert provider.service_account_id == "svac_env"
+    assert provider.workspace_id is None
+
+
+def test_missing_federation_id_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_FEDERATION_RULE_ID", raising=False)
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    with pytest.raises(ProviderConfigError, match="ANTHROPIC_FEDERATION_RULE_ID"):
+        from_oidc(
+            issuer="https://example.com",
+            token_fn=lambda: FAKE_JWT,
+        )
+
+
+def test_workspace_id_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_fn=lambda: FAKE_JWT,
+        workspace_id="wrkspc_explicit",
+        **_FED_KWARGS,
+    )
+    assert provider.workspace_id == "wrkspc_explicit"
+
+
+# -- End-to-end through the mocked exchange ------------------------------
+
+
+def test_env_var_mode_get_token_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Build-plan phase-2 acceptance criterion: the docstring example
+    (``from_oidc(issuer=..., token_env_var=...)``) works end-to-end with
+    a fake JWT in an env var and a mocked Anthropic exchange."""
+    monkeypatch.setenv("MY_OIDC_TOKEN", FAKE_JWT)
+    counter = _install_mock_exchange(monkeypatch)
+
+    provider = from_oidc(
+        issuer="https://gitlab.com",
+        token_env_var="MY_OIDC_TOKEN",
+        **_FED_KWARGS,
+    )
+    token = provider.get_token()
+    assert token == "sk-ant-oat01-mock"
+    assert counter["calls"] == 1
+    # Second call uses the cache — no second exchange.
+    assert provider.get_token() == "sk-ant-oat01-mock"
+    assert counter["calls"] == 1
+
+
+def test_file_mode_get_token_smoke(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    counter = _install_mock_exchange(monkeypatch)
+
+    provider = from_oidc(issuer="https://example.com", token_file=f, **_FED_KWARGS)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+    assert counter["calls"] == 1
+
+
+def test_callable_mode_get_auth_header_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_mock_exchange(monkeypatch)
+    provider = from_oidc(
+        issuer="https://example.com",
+        token_fn=lambda: FAKE_JWT,
+        **_FED_KWARGS,
+    )
+    assert provider.get_auth_header() == {"Authorization": "Bearer sk-ant-oat01-mock"}

--- a/tests/identity/providers/test_spiffe.py
+++ b/tests/identity/providers/test_spiffe.py
@@ -1,0 +1,377 @@
+"""Unit tests for the SPIFFE / SPIRE provider and ``from_spiffe``.
+
+pyspiffe is an *optional* dependency and is intentionally **not**
+installed in the dev venv (it has no extra to introspect). The SDK-mode
+tests therefore inject a fake ``pyspiffe.workloadapi.workload_api_client``
+module tree into ``sys.modules`` so the lazy import inside
+``_fetch_jwt_svid`` resolves to a stub. The missing-pyspiffe path sets
+the package to ``None`` in ``sys.modules`` so the lazy import raises
+ImportError — the same technique the AWS tests use for boto3. File mode
+uses a real temp file. No network access and no real credentials.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    ProviderConfigError,
+    SpiffeFileProvider,
+    SpiffeSdkProvider,
+    TokenAcquisitionError,
+)
+from promptise.identity.providers.spiffe import (
+    DEFAULT_SPIFFE_ENDPOINT_SOCKET,
+    ENV_SPIFFE_ENDPOINT_SOCKET,
+    from_spiffe,
+)
+
+FAKE_JWT: str = "header.payload.sig"
+
+# Synthetic federation IDs reused across tests — identifiers, not
+# secrets (build plan section 4.1).
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+# -- Fakes ----------------------------------------------------------------
+
+
+class _FakeJwtSvid:
+    """Stand-in for a pyspiffe JwtSvid with a configurable accessor.
+
+    The real serialized-token accessor varies across pyspiffe releases,
+    so the production code probes several. ``token_value`` is exposed
+    under the accessor named by ``accessor`` — either as a plain
+    attribute or as a zero-arg method, per ``as_method``.
+    """
+
+    def __init__(
+        self,
+        token_value: Any,
+        *,
+        accessor: str = "token",
+        as_method: bool = False,
+    ) -> None:
+        if as_method:
+            setattr(self, accessor, lambda: token_value)
+        else:
+            setattr(self, accessor, token_value)
+
+
+class _FakeWorkloadApiClient:
+    """Minimal stand-in for a pyspiffe WorkloadApiClient.
+
+    Records construction and call arguments on the class so tests can
+    assert on them, and returns a preconfigured JwtSvid (or raises).
+    """
+
+    last_socket_path: str | None = None
+    last_audiences: set[str] | None = None
+    close_calls: int = 0
+
+    def __init__(self, *, spiffe_socket_path: str) -> None:
+        type(self).last_socket_path = spiffe_socket_path
+
+    def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+        type(self).last_audiences = audiences
+        return _FakeJwtSvid(FAKE_JWT)
+
+    def close(self) -> None:
+        type(self).close_calls += 1
+
+
+def _install_fake_pyspiffe(
+    monkeypatch: pytest.MonkeyPatch, client_cls: type
+) -> None:
+    """Inject a fake ``pyspiffe.workloadapi.workload_api_client`` tree.
+
+    Makes ``from pyspiffe.workloadapi.workload_api_client import
+    WorkloadApiClient`` resolve to ``client_cls``.
+    """
+    pyspiffe_mod = types.ModuleType("pyspiffe")
+    workloadapi_mod = types.ModuleType("pyspiffe.workloadapi")
+    client_mod = types.ModuleType("pyspiffe.workloadapi.workload_api_client")
+    client_mod.WorkloadApiClient = client_cls  # type: ignore[attr-defined]
+    workloadapi_mod.workload_api_client = client_mod  # type: ignore[attr-defined]
+    pyspiffe_mod.workloadapi = workloadapi_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pyspiffe", pyspiffe_mod)
+    monkeypatch.setitem(sys.modules, "pyspiffe.workloadapi", workloadapi_mod)
+    monkeypatch.setitem(
+        sys.modules, "pyspiffe.workloadapi.workload_api_client", client_mod
+    )
+
+
+def _install_mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+# -- File mode ------------------------------------------------------------
+
+
+def test_file_mode_reads_token(tmp_path: Path) -> None:
+    f = tmp_path / "svid.jwt"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    provider = SpiffeFileProvider(token_file=f, **_FED_KWARGS)
+    assert provider.provider_name == "spiffe-file"
+    assert provider.token_file == f
+    assert provider._acquire_upstream_jwt() == FAKE_JWT
+
+
+def test_file_mode_get_token_smoke(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "svid.jwt"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    _install_mock_exchange(monkeypatch)
+    provider = SpiffeFileProvider(token_file=f, **_FED_KWARGS)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+# -- SDK mode: socket resolution ------------------------------------------
+
+
+def test_socket_path_explicit_argument_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_SPIFFE_ENDPOINT_SOCKET, "unix:///env/sock")
+    provider = SpiffeSdkProvider(socket_path="unix:///explicit/sock", **_FED_KWARGS)
+    assert provider._socket_path == "unix:///explicit/sock"
+
+
+def test_socket_path_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_SPIFFE_ENDPOINT_SOCKET, "unix:///env/sock")
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._socket_path == "unix:///env/sock"
+
+
+def test_socket_path_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_SPIFFE_ENDPOINT_SOCKET, raising=False)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._socket_path == DEFAULT_SPIFFE_ENDPOINT_SOCKET
+
+
+# -- SDK mode: fetch + extraction -----------------------------------------
+
+
+def test_sdk_fetches_and_extracts_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeWorkloadApiClient.last_socket_path = None
+    _FakeWorkloadApiClient.last_audiences = None
+    _FakeWorkloadApiClient.close_calls = 0
+    _install_fake_pyspiffe(monkeypatch, _FakeWorkloadApiClient)
+    provider = SpiffeSdkProvider(socket_path="unix:///tmp/agent.sock", **_FED_KWARGS)
+    assert provider.provider_name == "spiffe-sdk"
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+    assert _FakeWorkloadApiClient.last_socket_path == "unix:///tmp/agent.sock"
+    assert _FakeWorkloadApiClient.last_audiences == {"https://api.anthropic.com"}
+    # The client is closed after a successful fetch.
+    assert _FakeWorkloadApiClient.close_calls == 1
+
+
+def test_sdk_custom_audience_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeWorkloadApiClient.last_audiences = None
+    _install_fake_pyspiffe(monkeypatch, _FakeWorkloadApiClient)
+    provider = SpiffeSdkProvider(audience="https://custom.example.com", **_FED_KWARGS)
+    provider._fetch_jwt_svid()
+    assert _FakeWorkloadApiClient.last_audiences == {"https://custom.example.com"}
+
+
+def test_sdk_token_via_method_accessor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Some pyspiffe versions expose the serialized token under a method
+    (e.g. ``marshal()``) rather than an attribute."""
+
+    class _Client(_FakeWorkloadApiClient):
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            return _FakeJwtSvid(FAKE_JWT, accessor="marshal", as_method=True)
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+
+
+def test_sdk_token_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Client(_FakeWorkloadApiClient):
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            return _FakeJwtSvid(f"  {FAKE_JWT}\n", accessor="token_str")
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+
+
+def test_sdk_accessor_that_raises_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A callable accessor that raises must be skipped, falling through to
+    the next candidate accessor."""
+
+    class _Svid:
+        def token(self) -> str:  # first accessor — raises
+            raise RuntimeError("not this one")
+
+        serialize = FAKE_JWT  # later accessor — a plain attribute
+
+    class _Client(_FakeWorkloadApiClient):
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            return _Svid()
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+
+
+def test_sdk_unextractable_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Svid:
+        token = None
+        token_str = ""
+
+    class _Client(_FakeWorkloadApiClient):
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            return _Svid()
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(socket_path="unix:///tmp/agent.sock", **_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="serialized token could not be"):
+        provider._fetch_jwt_svid()
+
+
+def test_sdk_fetch_failure_raises_and_still_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Client(_FakeWorkloadApiClient):
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            raise RuntimeError("no agent listening")
+
+    _Client.close_calls = 0
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(socket_path="unix:///tmp/agent.sock", **_FED_KWARGS)
+    with pytest.raises(TokenAcquisitionError, match="fetching a JWT-SVID"):
+        provider._fetch_jwt_svid()
+    # The finally clause closes the client even when the fetch failed.
+    assert _Client.close_calls == 1
+
+
+def test_sdk_close_error_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A teardown failure must not mask a successful fetch result."""
+
+    class _Client(_FakeWorkloadApiClient):
+        def close(self) -> None:
+            raise RuntimeError("teardown blew up")
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+
+
+def test_sdk_client_without_close_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A client lacking a ``close`` method must not trip the teardown."""
+
+    class _Client:
+        def __init__(self, *, spiffe_socket_path: str) -> None:
+            pass
+
+        def fetch_jwt_svid(self, *, audiences: set[str]) -> Any:
+            return _FakeJwtSvid(FAKE_JWT)
+
+    _install_fake_pyspiffe(monkeypatch, _Client)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider._fetch_jwt_svid() == FAKE_JWT
+
+
+def test_sdk_missing_pyspiffe_raises_provider_config_error_with_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Build-plan phase-6 acceptance: the pyspiffe-not-installed error
+    names the exact ``pip install promptise[identity-spiffe]`` command and
+    surfaces as ProviderConfigError (not TokenAcquisitionError)."""
+    # Setting the package to None makes the lazy import raise ImportError.
+    monkeypatch.setitem(sys.modules, "pyspiffe", None)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    with pytest.raises(ProviderConfigError) as exc_info:
+        provider._fetch_jwt_svid()
+    assert "pip install promptise[identity-spiffe]" in str(exc_info.value)
+
+
+def test_sdk_get_token_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_pyspiffe(monkeypatch, _FakeWorkloadApiClient)
+    _install_mock_exchange(monkeypatch)
+    provider = SpiffeSdkProvider(**_FED_KWARGS)
+    assert provider.get_token() == "sk-ant-oat01-mock"
+
+
+# -- Factory --------------------------------------------------------------
+
+
+def test_from_spiffe_auto_picks_file_when_token_file_given(tmp_path: Path) -> None:
+    f = tmp_path / "svid.jwt"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    provider = from_spiffe(token_file=f, **_FED_KWARGS)
+    assert isinstance(provider, SpiffeFileProvider)
+
+
+def test_from_spiffe_auto_picks_sdk_when_no_token_file() -> None:
+    provider = from_spiffe(**_FED_KWARGS)
+    assert isinstance(provider, SpiffeSdkProvider)
+
+
+def test_from_spiffe_file_mode_requires_token_file() -> None:
+    with pytest.raises(ProviderConfigError, match="requires token_file"):
+        from_spiffe(mode="file", **_FED_KWARGS)
+
+
+def test_from_spiffe_file_mode_explicit(tmp_path: Path) -> None:
+    f = tmp_path / "svid.jwt"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    provider = from_spiffe(mode="file", token_file=f, **_FED_KWARGS)
+    assert isinstance(provider, SpiffeFileProvider)
+
+
+def test_from_spiffe_sdk_mode_passes_options() -> None:
+    provider = from_spiffe(
+        mode="sdk",
+        socket_path="unix:///tmp/custom.sock",
+        audience="https://aud.example.com",
+        **_FED_KWARGS,
+    )
+    assert isinstance(provider, SpiffeSdkProvider)
+    assert provider._socket_path == "unix:///tmp/custom.sock"
+    assert provider._audience == "https://aud.example.com"
+
+
+def test_from_spiffe_unknown_mode_raises() -> None:
+    with pytest.raises(ProviderConfigError, match="Unknown SPIFFE mode"):
+        from_spiffe(mode="bogus", **_FED_KWARGS)  # type: ignore[arg-type]
+
+
+def test_from_spiffe_workspace_id_passed_through() -> None:
+    provider = from_spiffe(workspace_id="wrkspc_explicit", **_FED_KWARGS)
+    assert provider.workspace_id == "wrkspc_explicit"
+
+
+def test_from_spiffe_missing_federation_id_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_FEDERATION_RULE_ID", raising=False)
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    with pytest.raises(ProviderConfigError, match="ANTHROPIC_FEDERATION_RULE_ID"):
+        from_spiffe()

--- a/tests/identity/test_agent_identity.py
+++ b/tests/identity/test_agent_identity.py
@@ -1,0 +1,226 @@
+"""Unit tests for the :class:`AgentIdentity` public class.
+
+Covers every factory classmethod (it wraps the right provider type),
+attribute forwarding to the underlying provider, the token-minting
+surface end-to-end through a mocked Anthropic exchange, the
+upstream-JWT accessor, and the identifier-only repr (which must never
+contain a token). No network access and no real credentials.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from promptise.identity import (
+    AgentIdentity,
+    AwsEksProjectedProvider,
+    AwsStsProvider,
+    EntraManagedIdentityProvider,
+    EntraProjectedTokenProvider,
+    GcpMetadataProvider,
+    IdentityProvider,
+    OidcCallableProvider,
+    SpiffeFileProvider,
+    SpiffeSdkProvider,
+)
+
+FAKE_JWT: str = "header.payload.sig"
+
+# Synthetic federation IDs — identifiers, not secrets (build plan 4.1).
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+def _install_mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+def _oidc_identity(**overrides: Any) -> AgentIdentity:
+    kwargs: dict[str, Any] = {
+        "issuer": "https://example.com",
+        "token_fn": lambda: FAKE_JWT,
+        **_FED_KWARGS,
+    }
+    kwargs.update(overrides)
+    return AgentIdentity.from_oidc(**kwargs)
+
+
+# -- Factories wrap the right provider ------------------------------------
+
+
+def test_from_entra_imds_wraps_managed_identity_provider() -> None:
+    identity = AgentIdentity.from_entra(mode="imds", **_FED_KWARGS)
+    assert isinstance(identity, AgentIdentity)
+    assert isinstance(identity.provider, EntraManagedIdentityProvider)
+
+
+def test_from_entra_projected_wraps_projected_provider(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    identity = AgentIdentity.from_entra(mode="projected", token_file=f, **_FED_KWARGS)
+    assert isinstance(identity.provider, EntraProjectedTokenProvider)
+
+
+def test_from_aws_sts_wraps_sts_provider() -> None:
+    identity = AgentIdentity.from_aws(mode="sts", region="us-east-1", **_FED_KWARGS)
+    assert isinstance(identity.provider, AwsStsProvider)
+
+
+def test_from_aws_projected_wraps_eks_provider(tmp_path: Path) -> None:
+    f = tmp_path / "token"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    identity = AgentIdentity.from_aws(mode="projected", token_file=f, **_FED_KWARGS)
+    assert isinstance(identity.provider, AwsEksProjectedProvider)
+
+
+def test_from_gcp_wraps_metadata_provider() -> None:
+    identity = AgentIdentity.from_gcp(**_FED_KWARGS)
+    assert isinstance(identity.provider, GcpMetadataProvider)
+
+
+def test_from_spiffe_sdk_wraps_sdk_provider() -> None:
+    identity = AgentIdentity.from_spiffe(mode="sdk", **_FED_KWARGS)
+    assert isinstance(identity.provider, SpiffeSdkProvider)
+
+
+def test_from_spiffe_file_wraps_file_provider(tmp_path: Path) -> None:
+    f = tmp_path / "svid.jwt"
+    f.write_text(FAKE_JWT, encoding="utf-8")
+    identity = AgentIdentity.from_spiffe(token_file=f, **_FED_KWARGS)
+    assert isinstance(identity.provider, SpiffeFileProvider)
+
+
+def test_from_oidc_wraps_callable_provider() -> None:
+    identity = _oidc_identity()
+    assert isinstance(identity.provider, OidcCallableProvider)
+
+
+def test_provider_property_returns_identity_provider() -> None:
+    identity = _oidc_identity()
+    assert isinstance(identity.provider, IdentityProvider)
+
+
+# -- Per-factory option pass-through --------------------------------------
+
+
+def test_from_gcp_passes_through_service_account_email() -> None:
+    identity = AgentIdentity.from_gcp(
+        service_account_email="agent@p.iam.gserviceaccount.com", **_FED_KWARGS
+    )
+    provider = identity.provider
+    assert isinstance(provider, GcpMetadataProvider)
+    assert provider._service_account_email == "agent@p.iam.gserviceaccount.com"
+
+
+def test_from_spiffe_passes_through_socket_and_audience() -> None:
+    identity = AgentIdentity.from_spiffe(
+        mode="sdk",
+        socket_path="unix:///tmp/custom.sock",
+        audience="https://aud.example.com",
+        **_FED_KWARGS,
+    )
+    provider = identity.provider
+    assert isinstance(provider, SpiffeSdkProvider)
+    assert provider._socket_path == "unix:///tmp/custom.sock"
+    assert provider._audience == "https://aud.example.com"
+
+
+def test_from_aws_passes_through_audience_and_algorithm() -> None:
+    identity = AgentIdentity.from_aws(
+        mode="sts",
+        region="eu-west-1",
+        audience="https://aud.example.com",
+        signing_algorithm="ES256",
+        **_FED_KWARGS,
+    )
+    provider = identity.provider
+    assert isinstance(provider, AwsStsProvider)
+    assert provider._audience == "https://aud.example.com"
+    assert provider._signing_algorithm == "ES256"
+
+
+# -- Attribute forwarding -------------------------------------------------
+
+
+def test_identity_attributes_forward_to_provider() -> None:
+    identity = _oidc_identity(workspace_id="wrkspc_x")
+    assert identity.provider_name == "oidc:https://example.com"
+    assert identity.federation_rule_id == "fdrl_test"
+    assert identity.organization_id == "org_test"
+    assert identity.service_account_id == "svac_test"
+    assert identity.workspace_id == "wrkspc_x"
+
+
+def test_workspace_id_is_none_when_unset() -> None:
+    identity = _oidc_identity()
+    assert identity.workspace_id is None
+
+
+def test_get_upstream_jwt_forwards() -> None:
+    identity = _oidc_identity()
+    assert identity.get_upstream_jwt() == FAKE_JWT
+
+
+# -- Token-minting surface end-to-end -------------------------------------
+
+
+def test_get_token_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_mock_exchange(monkeypatch)
+    identity = _oidc_identity()
+    assert identity.get_token() == "sk-ant-oat01-mock"
+
+
+def test_get_auth_header_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_mock_exchange(monkeypatch)
+    identity = _oidc_identity()
+    assert identity.get_auth_header() == {
+        "Authorization": "Bearer sk-ant-oat01-mock"
+    }
+
+
+# -- repr -----------------------------------------------------------------
+
+
+def test_repr_contains_identifiers_with_workspace() -> None:
+    identity = _oidc_identity(workspace_id="wrkspc_x")
+    text = repr(identity)
+    assert "AgentIdentity(" in text
+    assert "oidc:https://example.com" in text
+    assert "svac_test" in text
+    assert "wrkspc_x" in text
+
+
+def test_repr_omits_workspace_when_unset() -> None:
+    identity = _oidc_identity()
+    text = repr(identity)
+    assert "workspace_id" not in text
+
+
+def test_repr_never_contains_a_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The repr must never leak a credential, even after a token has been
+    minted and cached (build plan: never log/print a token)."""
+    _install_mock_exchange(monkeypatch)
+    identity = _oidc_identity()
+    identity.get_token()  # populate the cache
+    text = repr(identity)
+    assert "sk-ant-oat01-mock" not in text
+    assert FAKE_JWT not in text

--- a/tests/identity/test_auto_detection.py
+++ b/tests/identity/test_auto_detection.py
@@ -1,0 +1,170 @@
+"""Unit tests for platform auto-detection and ``AgentIdentity.auto``.
+
+``detect_platform`` is environment-variable driven, so every test
+starts from a clean slate (all detection markers removed) and sets only
+the markers under test. Covers each detection branch, the precedence
+ordering (Entra beats AWS beats GCP beats SPIFFE), empty-string markers
+counting as unset, the no-platform error, and the ``auto`` dispatch
+wiring each detected platform to the right provider. No network access
+and no real credentials.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from promptise.identity import (
+    AgentIdentity,
+    AwsEksProjectedProvider,
+    EntraProjectedTokenProvider,
+    GcpMetadataProvider,
+    PlatformDetectionError,
+    SpiffeSdkProvider,
+)
+from promptise.identity._internal.detect import detect_platform
+
+# Synthetic federation IDs — identifiers, not secrets (build plan 4.1).
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+# Every environment marker the detector inspects, across all platforms.
+_ALL_MARKERS: tuple[str, ...] = (
+    "AZURE_FEDERATED_TOKEN_FILE",
+    "AZURE_CLIENT_ID",
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "AWS_EXECUTION_ENV",
+    "EKS_POD_NAME",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "GOOGLE_CLOUD_PROJECT",
+    "K_SERVICE",
+    "GCE_METADATA_IP",
+    "SPIFFE_ENDPOINT_SOCKET",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_markers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every detection marker so each test controls the env."""
+    for name in _ALL_MARKERS:
+        monkeypatch.delenv(name, raising=False)
+
+
+# -- Single-platform detection --------------------------------------------
+
+
+@pytest.mark.parametrize("marker", ["AZURE_FEDERATED_TOKEN_FILE", "AZURE_CLIENT_ID"])
+def test_detects_entra(monkeypatch: pytest.MonkeyPatch, marker: str) -> None:
+    monkeypatch.setenv(marker, "value")
+    assert detect_platform() == "entra"
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "AWS_LAMBDA_FUNCTION_NAME",
+        "AWS_EXECUTION_ENV",
+        "EKS_POD_NAME",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    ],
+)
+def test_detects_aws(monkeypatch: pytest.MonkeyPatch, marker: str) -> None:
+    monkeypatch.setenv(marker, "value")
+    assert detect_platform() == "aws"
+
+
+@pytest.mark.parametrize(
+    "marker", ["GOOGLE_CLOUD_PROJECT", "K_SERVICE", "GCE_METADATA_IP"]
+)
+def test_detects_gcp(monkeypatch: pytest.MonkeyPatch, marker: str) -> None:
+    monkeypatch.setenv(marker, "value")
+    assert detect_platform() == "gcp"
+
+
+def test_detects_spiffe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPIFFE_ENDPOINT_SOCKET", "unix:///tmp/agent.sock")
+    assert detect_platform() == "spiffe"
+
+
+# -- Precedence -----------------------------------------------------------
+
+
+def test_entra_beats_aws(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_CLIENT_ID", "x")
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "y")
+    assert detect_platform() == "entra"
+
+
+def test_aws_beats_gcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_EXECUTION_ENV", "x")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "y")
+    assert detect_platform() == "aws"
+
+
+def test_gcp_beats_spiffe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("K_SERVICE", "x")
+    monkeypatch.setenv("SPIFFE_ENDPOINT_SOCKET", "unix:///tmp/agent.sock")
+    assert detect_platform() == "gcp"
+
+
+# -- Empty / missing markers ----------------------------------------------
+
+
+def test_empty_marker_counts_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_CLIENT_ID", "")  # declared but empty
+    with pytest.raises(PlatformDetectionError):
+        detect_platform()
+
+
+def test_no_markers_raises_platform_detection_error() -> None:
+    with pytest.raises(PlatformDetectionError, match="could not auto-detect"):
+        detect_platform()
+
+
+# -- AgentIdentity.auto dispatch ------------------------------------------
+
+
+def test_auto_dispatches_to_entra(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text("header.payload.sig", encoding="utf-8")
+    monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(f))
+    identity = AgentIdentity.auto(**_FED_KWARGS)
+    # mode="auto" + a projected token file present => projected provider.
+    assert isinstance(identity.provider, EntraProjectedTokenProvider)
+    assert identity.federation_rule_id == "fdrl_test"
+
+
+def test_auto_dispatches_to_aws(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    f = tmp_path / "token"
+    f.write_text("header.payload.sig", encoding="utf-8")
+    monkeypatch.setenv("EKS_POD_NAME", "my-pod")
+    # Make from_aws(mode="auto") pick projected mode (no region/boto3 needed).
+    monkeypatch.setenv("ANTHROPIC_IDENTITY_TOKEN_FILE", str(f))
+    identity = AgentIdentity.auto(**_FED_KWARGS)
+    assert isinstance(identity.provider, AwsEksProjectedProvider)
+
+
+def test_auto_dispatches_to_gcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+    identity = AgentIdentity.auto(**_FED_KWARGS)
+    assert isinstance(identity.provider, GcpMetadataProvider)
+
+
+def test_auto_dispatches_to_spiffe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPIFFE_ENDPOINT_SOCKET", "unix:///tmp/agent.sock")
+    identity = AgentIdentity.auto(**_FED_KWARGS)
+    # mode="auto" + no token_file => SDK mode.
+    assert isinstance(identity.provider, SpiffeSdkProvider)
+
+
+def test_auto_raises_when_no_platform() -> None:
+    with pytest.raises(PlatformDetectionError):
+        AgentIdentity.auto(**_FED_KWARGS)

--- a/tests/test_build_agent_with_identity.py
+++ b/tests/test_build_agent_with_identity.py
@@ -1,0 +1,158 @@
+"""Tests for ``build_agent(identity=...)`` — Phase 8 identity integration.
+
+Covers the credential-precedence guard (a static ANTHROPIC_API_KEY must
+not silently shadow a federated identity), the ``agent.identity``
+attribute, and the federated-token injection in ``_normalize_model``
+(an Anthropic OAuth bearer token reaches the model's Authorization
+header, with no static key required). The heavy graph/model internals
+are mocked exactly as the existing core-agent E2E tests do — no network
+and no real credentials.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from promptise.agent import PromptiseAgent, _normalize_model, build_agent
+from promptise.identity import AgentIdentity, CredentialPrecedenceError
+
+FAKE_JWT: str = "header.payload.sig"
+
+# Synthetic federation IDs — identifiers, not secrets (build plan 4.1).
+_FED_KWARGS: dict[str, str] = {
+    "federation_rule_id": "fdrl_test",
+    "organization_id": "org_test",
+    "service_account_id": "svac_test",
+}
+
+
+def _identity() -> AgentIdentity:
+    """An OIDC identity whose upstream JWT needs no network."""
+    return AgentIdentity.from_oidc(
+        issuer="https://example.com",
+        token_fn=lambda: FAKE_JWT,
+        **_FED_KWARGS,
+    )
+
+
+def _mock_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"access_token": "sk-ant-oat01-mock", "expires_in": 3600},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mocked_post(url: str, **kwargs: Any) -> httpx.Response:
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "post", mocked_post)
+
+
+def _make_mock_inner() -> MagicMock:
+    mock = MagicMock()
+    mock.ainvoke = AsyncMock(return_value={"messages": []})
+    mock.invoke = MagicMock(return_value={"messages": []})
+    return mock
+
+
+# -- Credential-precedence guard ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identity_with_api_key_env_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A static ANTHROPIC_API_KEY alongside an identity must hard-fail."""
+    # Sentinel value — presence is what the guard checks, not the content.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-for-test")
+    with pytest.raises(CredentialPrecedenceError, match="silently shadow"):
+        await build_agent(
+            servers={},
+            model="anthropic:claude-3-5-sonnet-latest",
+            identity=_identity(),
+        )
+
+
+# -- agent.identity attribute ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_agent_stores_identity_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no ANTHROPIC_API_KEY set, an agent builds and exposes the
+    identity (build-plan phase-8 acceptance criterion)."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    identity = _identity()
+    mock_graph = _make_mock_inner()
+
+    with (
+        patch("promptise.agent._normalize_model") as mock_norm,
+        patch("promptise.agent.PromptGraphEngine", return_value=mock_graph),
+        patch.dict("sys.modules", {"deepagents": None}),
+    ):
+        mock_norm.return_value = MagicMock()
+        agent = await build_agent(
+            servers={},
+            model="anthropic:claude-3-5-sonnet-latest",
+            identity=identity,
+        )
+
+    assert isinstance(agent, PromptiseAgent)
+    assert agent.identity is identity
+    # build_agent forwards the identity into model normalization.
+    mock_norm.assert_called_once()
+    assert mock_norm.call_args.args[1] is identity
+
+
+@pytest.mark.asyncio
+async def test_build_agent_identity_defaults_to_none() -> None:
+    mock_graph = _make_mock_inner()
+    with (
+        patch("promptise.agent._normalize_model", return_value=MagicMock()),
+        patch("promptise.agent.PromptGraphEngine", return_value=mock_graph),
+        patch.dict("sys.modules", {"deepagents": None}),
+    ):
+        agent = await build_agent(servers={}, model="openai:gpt-5-mini")
+    assert agent.identity is None
+
+
+# -- Federated-token injection in _normalize_model ------------------------
+
+
+def test_normalize_model_injects_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A string Anthropic model + identity => the minted OAuth token is
+    placed in the Authorization header (no static key needed)."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _mock_exchange(monkeypatch)
+    model = _normalize_model("anthropic:claude-3-5-sonnet-latest", _identity())
+    headers = model.default_headers  # type: ignore[attr-defined]
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer sk-ant-oat01-mock"
+
+
+def test_normalize_model_without_identity_has_no_auth_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A sentinel api key lets ChatAnthropic construct; presence/content is
+    # irrelevant to the assertion (we only check no Authorization header).
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-for-test")
+    model = _normalize_model("anthropic:claude-3-5-sonnet-latest")
+    assert not getattr(model, "default_headers", None)
+
+
+def test_normalize_model_passes_through_prebuilt_model() -> None:
+    """A pre-built chat model instance is returned untouched even when an
+    identity is supplied — there is nothing to inject into."""
+    sentinel = MagicMock()
+    result = _normalize_model(sentinel, _identity())
+    assert result is sentinel


### PR DESCRIPTION
## Summary

A new foundation subsystem — `promptise.identity` — that gives AI agents
**federated authentication with zero static credentials**. Every provider emits
an OIDC JWT from the platform it runs on; the framework exchanges it for a
short-lived Anthropic access token via RFC 7523 (`jwt-bearer`), caches it, and
refreshes it transparently.

```python
from promptise import build_agent
from promptise.identity import AgentIdentity

agent = await build_agent(
    model="anthropic:claude-sonnet-4-5",
    servers={},
    identity=AgentIdentity.from_aws(),   # zero args, reads the environment
)
```

The public surface is one class, `AgentIdentity`, with five `from_*` factories
plus `auto()`. Built in 11 reviewed phases.

## What's included

- **Core** — `MintedToken`, the RFC 7523 exchange engine, `IdentityProvider`
  base (thread-safe cache, two-tier refresh: advisory −120s / mandatory −30s,
  `time.monotonic()` expiry), and `FileTokenProvider` / `CallableTokenProvider`.
- **Providers** — Microsoft Entra (IMDS + AKS projected), AWS IAM (STS +
  EKS-projected), Google Cloud (metadata server), SPIFFE/SPIRE (Workload API +
  spiffe-helper file), Generic OIDC (file/callable/env-var).
- **`AgentIdentity`** + environment-based platform `auto()` detection.
- **`build_agent(identity=…)`** integration with a `CredentialPrecedenceError`
  guard and an `agent.identity` attribute.
- **Docs** — overview, quickstart, architecture (Mermaid), per-provider pages,
  security, migration, and an API reference.
- **Examples** — AWS Lambda, GKE, AKS, GitHub Actions, SPIRE — plus a live
  federation CI workflow.

## Optional dependencies

`boto3` (AWS STS) and `pyspiffe` (SPIFFE SDK) are **optional**, imported inside
the acquisition method, never at module load. Missing → `ProviderConfigError`
naming the exact install command. New extras: `identity-aws`,
`identity-spiffe`, `identity-all`.

## Deviations from the build plan (flagged for review)

1. **`build_agent` integration.** The plan's §6 assumed
   `anthropic.WorkloadIdentityCredentials`, which does **not** exist in the
   installed anthropic SDK (0.96.0), and `build_agent()` builds models through
   LangChain `init_chat_model`, not a raw client. Integration is done at the
   model-construction layer via a bearer `default_headers` injection (the same
   header shape the SDK's `auth_token` produces). See
   `src/promptise/identity/DEFERRED.md` item 2.
2. **HTTP client.** `httpx` instead of the plan's `requests` (httpx is already a
   transitive dependency across ~17 packages; no new dep).
3. **Test path.** `tests/test_build_agent_with_identity.py` (flat) rather than
   the plan's `tests/agent/…`, matching the repo's flat `tests/` convention.
4. **Out-of-tree files** (all plan-authorized or necessary): `pyproject.toml`
   (extras), `src/promptise/agent.py` (the one allowed Phase-8 edit),
   `mkdocs.yml` + `docs/api/identity.md` (docs nav/API ref),
   `.github/workflows/identity-integration.yml` (Phase-10 deliverable).

## ⚠️ Manual step required

The live CI federation test
(`.github/workflows/identity-integration.yml`) **skips gracefully** until a
maintainer (1) registers a Workload Identity Federation rule for the GitHub
Actions OIDC issuer in the Anthropic Console, and (2) sets repo variables
`ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_ORGANIZATION_ID`,
`ANTHROPIC_SERVICE_ACCOUNT_ID`. It stays green on forks/unconfigured repos.

## Quality gates

- `ruff check` — clean; `mypy --strict src/promptise/identity` — clean (19 files)
- Coverage — **100%** line + branch across the identity tree (`coverage` CLI)
- **179** new identity tests; full suite **3328 passed, 1 skipped**, no regression
- `mkdocs build --strict` — passes
- No `TODO/FIXME/XXX/NotImplementedError/print()` in the identity source; no
  credentials in code, tests, or docs

## Test plan

- [ ] CI green (lint, types, full test suite, docs strict build)
- [ ] Review the `build_agent` integration approach + `DEFERRED.md` items
- [ ] (Maintainer) complete the federation-rule manual step to enable the live
      CI test
- [ ] Smoke-test the quickstart (OIDC env-var mode) end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)