### PR TITLE
fix(deps): cap mcp<2.0 (v1.1.1) — mcp 2.0 breaks the server SDK

### DIFF
--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -4,6 +4,14 @@ All notable changes to Promptise Foundry are documented here.
 
 ---
 
+## v1.1.1 — 2026-07-17
+
+### Fixed
+
+- **Dependencies: cap `mcp<2.0`** -- mcp 2.0 changed the low-level `Server()` constructor signature and renamed `ResourceTemplate.uriTemplate` to `uri_template`, which breaks the MCP server SDK. With the previous uncapped `mcp>=1.9.0`, a fresh `pip install promptise` resolved to mcp 2.0 and the server SDK failed at runtime. Pinned to `mcp>=1.9.0,<2.0` (validated against mcp 1.29.0 with the full suite green alongside the latest cryptography, starlette, langchain-openai, and pydantic). Support for the mcp 2.0 API is tracked as a follow-up.
+
+---
+
 ## v1.1.0 — 2026-07-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
 
 dependencies = [
   # Core agent framework
-  "mcp>=1.9.0",
+  # Capped below 2.0: mcp 2.0 changed the low-level Server() signature and
+  # renamed ResourceTemplate.uriTemplate -> uri_template, which breaks the
+  # server SDK. Lift the cap once the SDK is ported to the 2.0 API.
+  "mcp>=1.9.0,<2.0",
   "langchain>=0.3.27",
   "pydantic>=2.13.3",
   "typer>=0.15.2",


### PR DESCRIPTION
## Cap `mcp<2.0` — fixes broken fresh installs

mcp 2.0 changed the low-level `Server()` constructor signature and renamed `ResourceTemplate.uriTemplate` → `uri_template`, which breaks the MCP server SDK. Because `mcp>=1.9.0` had no upper cap, a fresh `pip install promptise` (including the published **v1.1.0**) resolves to mcp 2.0 and the server SDK fails at runtime.

### Fix
- Cap `mcp>=1.9.0,<2.0`
- Changelog entry for v1.1.1

### Validation
- **Full suite: 3493 passed** with mcp 1.29.0 alongside the latest cryptography 50, starlette 1.6, langchain-openai 1.5, pydantic 2.13.4 — confirming no other dependency needs a cap.
- **pip-audit:** no shipped dependency has a known vulnerability (all hits are dev/docs/benchmark transitives that never reach `pip install promptise`).

Follow-up: port the server SDK to the mcp 2.0 API so the cap can be lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)