### PR TITLE
docs(mcp): add optional Parallel web search example

### DIFF
--- a/docs/mcp/client/index.md
+++ b/docs/mcp/client/index.md
@@ -44,6 +44,33 @@ async with MCPClient(url="http://localhost:8080/mcp") as client:
     tools = await client.list_tools()
 ```
 
+### Optional: web search with Parallel
+
+The hosted Parallel MCP endpoint is an optional unauthenticated server, so no account or API key is needed. This runnable example uses the native async client to request a web search:
+
+```python
+import asyncio
+
+from promptise import MCPClient
+
+
+async def main():
+    async with MCPClient(url="https://search.parallel.ai/mcp") as client:
+        result = await client.call_tool(
+            "web_search",
+            {
+                "objective": "Find official Python asyncio documentation",
+                "search_queries": ["Python asyncio official documentation"],
+            },
+        )
+        print(result.content[0].text)
+
+
+asyncio.run(main())
+```
+
+When you choose to use this endpoint, your submitted search objectives, search queries, and any URLs you request are sent to Parallel.
+
 ### Bearer token authentication
 
 ```python


### PR DESCRIPTION
## Description

Adds an optional runnable example showing how to call Parallel's unauthenticated hosted MCP endpoint with Foundry's native async `MCPClient`. The accompanying note clarifies that no account or API key is required and that user-provided search objectives, search queries, and requested URLs are sent to Parallel when the endpoint is used.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD improvement

## Related Issues

None.

## Changes Made

- Added an optional native async `MCPClient` web-search example.
- Documented that the endpoint does not require an account or API key.
- Disclosed the search objectives, search queries, and requested URLs sent when users opt into the endpoint.

## Testing

- [ ] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Tested manually (describe below)

**Manual Testing Details:**

- Parsed the added Python snippet with Python's AST parser.
- Ran `git diff --check`.
- Confirmed `docs/mcp/client/index.md` is the only changed path.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated docstrings
- [x] Updated `/docs` (if applicable)
- [x] Updated examples (if applicable)

## Screenshots/Examples

The runnable example is included directly in the MCP client documentation.

## Breaking Changes

None.

## Additional Notes

This additive documentation example does not change any default, provider, configuration, authentication behavior, or security expectation.

## Code of Conduct

- [x] I have read and agree to follow the Code of Conduct

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.